### PR TITLE
Feat platform 441 client access to command types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 cjs
 esm
 TODO.md
+.idea

--- a/src/models/command-type.ts
+++ b/src/models/command-type.ts
@@ -14,6 +14,8 @@ const schema = Joi.object().keys({
     .description('See the chapter on open fields on how to use this'),
   channelSelect: Joi.string().valid('single', 'multiple', 'off').required().example('off')
     .description('When creating a command of this type, the user can then optionally choose one (in case of \'single\') or more channelIndices (in case of \'multiple\') for which this command is relevant. If \'off\' is chosen, the user cannot specify channelIndices'),
+  clientAccess: Joi.string().valid('full', 'read', 'none').required().example('none')
+    .description('\'full\': end-users can view, create and delete commands of this type. \'read\': end-users can view but not create and delete commands of this type. \'none\': end-users cannot view, create or delete commands of this type.'),
 })
   .description('An object defining what a command type should look like: the template for commands sent to devices')
   .tag('commandType');
@@ -26,6 +28,7 @@ interface CommandType {
   supplierOnly: boolean;
   fieldConfigurations: FieldConfigurationsFromServer;
   channelSelect: 'single' | 'multiple' | 'off';
+  clientAccess: 'full' | 'read' | 'none';
 }
 
 export {

--- a/src/routes/command-type/add.ts
+++ b/src/routes/command-type/add.ts
@@ -10,6 +10,7 @@ interface Request {
     supplierOnly?: boolean;
     fieldConfigurations: FieldConfigurationsToServer;
     channelSelect?: 'single' | 'multiple' | 'off';
+    clientAccess?: 'full' | 'read' | 'none';
   };
 }
 
@@ -33,6 +34,8 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
       .description('See the chapter on open fields on how to use this'),
     channelSelect: Joi.string().valid('single', 'multiple', 'off').default('off')
       .description('When creating a command of this type, the user can then optionally choose one (in case of \'single\') or more channelIndices (in case of \'multiple\') for which this command is relevant. If \'off\' is chosen, the user cannot specify channelIndices'),
+    clientAccess: Joi.string().valid('full', 'read', 'none').default('full')
+      .description('\'full\': end-users can view, create and delete commands of this type. \'read\': end-users can view but not create and delete commands of this type. \'none\': end-users cannot view, create or delete commands of this type.'),
   }).required(),
   right: { supplier: 'ENVIRONMENT_ADMIN' },
   response: Joi.object().keys({

--- a/src/routes/command-type/update.ts
+++ b/src/routes/command-type/update.ts
@@ -16,6 +16,7 @@ interface Request {
     supplierOnly?: boolean;
     fieldConfigurations?: UpdatableFieldConfigurations;
     channelSelect?: 'single' | 'multiple' | 'off';
+    clientAccess?: 'full' | 'read' | 'none';
   };
 }
 
@@ -35,6 +36,8 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
     fieldConfigurations: updatableFieldConfigurationsSchema.description('See the chapter on open fields on how to use this'),
     channelSelect: Joi.string().valid('single', 'multiple', 'off')
       .description('When creating a command of this type, the user can then optionally choose one (in case of \'single\') or more channelIndices (in case of \'multiple\') for which this command is relevant. If \'off\' is chosen, the user cannot specify channelIndices'),
+    clientAccess: Joi.string().valid('full', 'read', 'none').default('full')
+      .description('\'full\': end-users can view, create and delete commands of this type. \'read\': end-users can view but not create and delete commands of this type. \'none\': end-users cannot view, create or delete commands of this type.'),
   }).required(),
   right: { supplier: 'ENVIRONMENT_ADMIN' },
   description: 'Update a command type.',


### PR DESCRIPTION
This branch adds `clientAccess` field to schemas and interfaces and leaves `suppliersOnly` for back compatibility. 

It need to be published to registry with separate version number