### PR TITLE
Feat platform 441 remove supplier only property

### DIFF
--- a/src/models/command-type.ts
+++ b/src/models/command-type.ts
@@ -9,7 +9,6 @@ const schema = Joi.object().keys({
     .description('\'required\': user must provide command.startAt. \'optional\': user can provide command.startAt or a delay for the command to start after it is sent to the device. \'disabled\': user cannot provide command.startAt nor a delay.'),
   end: Joi.string().valid('required', 'optional', 'disabled').required().example('disabled')
     .description('\'required\': user must provide command.endAt. \'optional\': user can provide command.endAt. \'disabled\': user cannot provide command.endAt.'),
-  supplierOnly: Joi.boolean().required().example(false).description('If true, this type of command can not be created from a monitoring environment but only from a connectivity environment'),
   fieldConfigurations: fieldConfigurationsFromServerSchema.required()
     .description('See the chapter on open fields on how to use this'),
   channelSelect: Joi.string().valid('single', 'multiple', 'off').required().example('off')
@@ -25,7 +24,6 @@ interface CommandType {
   name: string;
   start: 'required' | 'optional' | 'disabled';
   end: 'required' | 'optional' | 'disabled';
-  supplierOnly: boolean;
   fieldConfigurations: FieldConfigurationsFromServer;
   channelSelect: 'single' | 'multiple' | 'off';
   clientAccess: 'full' | 'read' | 'none';

--- a/src/routes/command-type/add.ts
+++ b/src/routes/command-type/add.ts
@@ -7,7 +7,6 @@ interface Request {
     name: string;
     start?: 'required' | 'optional' | 'disabled';
     end?: 'required' | 'optional' | 'disabled';
-    supplierOnly?: boolean;
     fieldConfigurations: FieldConfigurationsToServer;
     channelSelect?: 'single' | 'multiple' | 'off';
     clientAccess?: 'full' | 'read' | 'none';
@@ -29,7 +28,6 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
     name: Joi.string().required().example('Measurement cycle'),
     start: Joi.string().valid('required', 'optional', 'disabled').default('optional').description('\'required\': user must provide command.startAt. \'optional\': user can provide command.startAt or a delay for the command to start after it is sent to the device. \'disabled\': user cannot provide command.startAt nor a delay.'),
     end: Joi.string().valid('required', 'optional', 'disabled').default('disabled').description('\'required\': user must provide command.endAt. \'optional\': user can provide command.endAt. \'disabled\': user cannot provide command.endAt.'),
-    supplierOnly: Joi.boolean().default(false).description('If true, this type of command can not be created from a monitoring environment, but only from a connectivity environment'),
     fieldConfigurations: fieldConfigurationsToServerSchema.required()
       .description('See the chapter on open fields on how to use this'),
     channelSelect: Joi.string().valid('single', 'multiple', 'off').default('off')

--- a/src/routes/command-type/update.ts
+++ b/src/routes/command-type/update.ts
@@ -13,7 +13,6 @@ interface Request {
     name?: string;
     start?: 'required' | 'optional' | 'disabled';
     end?: 'required' | 'optional' | 'disabled';
-    supplierOnly?: boolean;
     fieldConfigurations?: UpdatableFieldConfigurations;
     channelSelect?: 'single' | 'multiple' | 'off';
     clientAccess?: 'full' | 'read' | 'none';
@@ -32,7 +31,6 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
     name: Joi.string().example('Measurement cycle'),
     start: Joi.string().valid('required', 'optional', 'disabled').description('\'required\': user must provide command.startAt. \'optional\': user can provide command.startAt or a delay for the command to start after it is sent to the device. \'disabled\': user cannot provide command.startAt nor a delay.'),
     end: Joi.string().valid('required', 'optional', 'disabled').description('\'required\': user must provide command.endAt. \'optional\': user can provide command.endAt. \'disabled\': user cannot provide command.endAt.'),
-    supplierOnly: Joi.boolean().description('If true, this type of command can not be created from a monitoring environment, but only from a connectivity environment'),
     fieldConfigurations: updatableFieldConfigurationsSchema.description('See the chapter on open fields on how to use this'),
     channelSelect: Joi.string().valid('single', 'multiple', 'off')
       .description('When creating a command of this type, the user can then optionally choose one (in case of \'single\') or more channelIndices (in case of \'multiple\') for which this command is relevant. If \'off\' is chosen, the user cannot specify channelIndices'),


### PR DESCRIPTION
This branch removes `supplierOnly` property from interfaces and schemas