### PR TITLE
feat platform 391: disable SI prefixes for quantities

### DIFF
--- a/src/models/quantity.ts
+++ b/src/models/quantity.ts
@@ -13,6 +13,7 @@ const schema = Joi.object().keys({
   defaultLowThreshold: siNumberSchema.allow(null).default(null),
   defaultHighThreshold: siNumberSchema.allow(null).default(null),
   defaultCriticallyHighThreshold: siNumberSchema.allow(null).default(null),
+  disableSiPrefixes: Joi.boolean().default(false).example(true).description('Will disable SI-prefixes for this quantity if true'),
 })
   .tag('quantity');
 
@@ -25,6 +26,7 @@ interface Quantity {
   defaultLowThreshold: SiNumber | null;
   defaultHighThreshold: SiNumber | null;
   defaultCriticallyHighThreshold: SiNumber | null;
+  disableSiPrefixes: boolean;
 }
 
 export { schema, Quantity };

--- a/src/routes/quantity/add.ts
+++ b/src/routes/quantity/add.ts
@@ -11,6 +11,7 @@ interface Request {
     defaultLowThreshold: SiNumber | null;
     defaultHighThreshold: SiNumber | null;
     defaultCriticallyHighThreshold: SiNumber | null;
+    disableSiPrefixes: boolean;
   };
 }
 
@@ -32,6 +33,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
     defaultLowThreshold: siNumberSchema.allow(null).default(null),
     defaultHighThreshold: siNumberSchema.allow(null).default(null),
     defaultCriticallyHighThreshold: siNumberSchema.allow(null).default(null),
+    disableSiPrefixes: Joi.boolean().default(false).example(true).description('Will disable SI-prefixes for this quantity if true'),
   }).required(),
   right: { environment: 'ENVIRONMENT_ADMIN', supplier: 'ENVIRONMENT_ADMIN' },
   response: Joi.object().keys({

--- a/src/routes/quantity/update.ts
+++ b/src/routes/quantity/update.ts
@@ -14,6 +14,7 @@ interface Request {
     defaultLowThreshold?: SiNumber | null;
     defaultHighThreshold?: SiNumber | null;
     defaultCriticallyHighThreshold?: SiNumber | null;
+    disableSiPrefixes?: boolean;
   };
 }
 
@@ -35,6 +36,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
     defaultLowThreshold: siNumberSchema.allow(null),
     defaultHighThreshold: siNumberSchema.allow(null),
     defaultCriticallyHighThreshold: siNumberSchema.allow(null),
+    disableSiPrefixes: Joi.boolean().example(true).description('Will disable SI-prefixes for this quantity'),
   }).required(),
   right: { environment: 'ENVIRONMENT_ADMIN', supplier: 'ENVIRONMENT_ADMIN' },
 };

--- a/src/routes/report-type/add.ts
+++ b/src/routes/report-type/add.ts
@@ -11,6 +11,7 @@ type RequestQuantity = {
   defaultLowThreshold: SiNumber | null;
   defaultHighThreshold: SiNumber | null;
   defaultCriticallyHighThreshold: SiNumber | null;
+  disableSiPrefixes: boolean;
 } | {
   hashId: string;
 };
@@ -54,6 +55,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
         defaultLowThreshold: siNumberSchema.allow(null).default(null),
         defaultHighThreshold: siNumberSchema.allow(null).default(null),
         defaultCriticallyHighThreshold: siNumberSchema.allow(null).default(null),
+        disableSiPrefixes: Joi.boolean().default(false).example(true).description('Will disable SI-prefixes for this quantity if true'),
       }),
       Joi.object().keys({
         hashId: Joi.string().required(),

--- a/src/routes/report-type/update.ts
+++ b/src/routes/report-type/update.ts
@@ -14,6 +14,7 @@ type RequestQuantity = {
   defaultLowThreshold: SiNumber | null;
   defaultHighThreshold: SiNumber | null;
   defaultCriticallyHighThreshold: SiNumber | null;
+  disableSiPrefixes: boolean;
 } | {
   hashId: string;
 };
@@ -60,6 +61,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
         defaultLowThreshold: siNumberSchema.allow(null).default(null),
         defaultHighThreshold: siNumberSchema.allow(null).default(null),
         defaultCriticallyHighThreshold: siNumberSchema.allow(null).default(null),
+        disableSiPrefixes: Joi.boolean().default(false).example(true).description('Will disable SI-prefixes for this quantity if true'),
       }),
       Joi.object().keys({
         hashId: Joi.string().required(),


### PR DESCRIPTION
added disableSiPrefixes field to interfaces and schemas related to the quantities model