### PR TITLE
feat(supplier-activities, device.link, graph.get-edge, graph.get-pin-group): expect next report before

### DIFF
--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -10,6 +10,7 @@ const schema = Joi.object().keys({
   deviceTypeHashId: Joi.string().required().example('wasd2'),
   fields: fieldsFromServerSchema.required().example({}),
   measurementCycle: measurementCycleSchema.allow(null).required(),
+  nextReportBefore: Joi.date().allow(null).required().example('2019-12-31T15:25Z'),
   lastOnlineAt: Joi.date().allow(null).required().example('2019-12-31T15:23Z'),
   validated: Joi.boolean().required().example(true),
 })
@@ -23,6 +24,7 @@ interface Device {
   deviceTypeHashId: string;
   fields: FieldsFromServer;
   measurementCycle: MeasurementCycle | null;
+  nextReportBefore: Date | null;
   lastOnlineAt: Date | null;
   validated: boolean;
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -54,6 +54,7 @@ import * as supplierActivityScheduleCommand from './supplier-activities/schedule
 import * as supplierActivitySendRequest from './supplier-activities/send-request';
 import * as supplierActivitySetDeviceFields from './supplier-activities/set-device-fields';
 import * as supplierActivitySetReportingFrequency from './supplier-activities/set-reporting-frequency';
+import * as supplierActivityExpectNextReportBefore from './supplier-activities/expect-next-report-before';
 import * as supplierCertificate from './supplier-certificate';
 import * as supplierReportType from './supplier-report-type';
 import * as supplierWebhook from './supplier-webhook';
@@ -117,6 +118,7 @@ export {
   supplierActivitySendRequest,
   supplierActivitySetDeviceFields,
   supplierActivitySetReportingFrequency,
+  supplierActivityExpectNextReportBefore,
   supplierCertificate,
   supplierReportType,
   supplierWebhook,

--- a/src/models/supplier-activities/all-activities.ts
+++ b/src/models/supplier-activities/all-activities.ts
@@ -15,6 +15,7 @@ import { schema as scheduleCommandSchema, ScheduleCommand } from './schedule-com
 import { schema as sendRequestSchema, SendRequest } from './send-request';
 import { schema as setDeviceFieldsSchema, SetDeviceFields } from './set-device-fields';
 import { schema as setReportingFrequencySchema, SetReportingFrequency } from './set-reporting-frequency';
+import { schema as expectNextReportBeforeSchema, ExpectNextReportBefore } from './expect-next-report-before';
 
 type AllActivities = DropCommand
   | HandleCommandDue
@@ -30,7 +31,8 @@ type AllActivities = DropCommand
   | ScheduleCommand
   | SendRequest
   | SetDeviceFields
-  | SetReportingFrequency;
+  | SetReportingFrequency
+  | ExpectNextReportBefore;
 
 const schema = (apiVersion: number): Joi.AlternativesSchema => Joi.alternatives().try(
   dropCommandSchema,
@@ -48,6 +50,7 @@ const schema = (apiVersion: number): Joi.AlternativesSchema => Joi.alternatives(
   sendRequestSchema,
   setDeviceFieldsSchema,
   setReportingFrequencySchema,
+  expectNextReportBeforeSchema,
 );
 
 export { schema, AllActivities };

--- a/src/models/supplier-activities/device-type-handler-activity.ts
+++ b/src/models/supplier-activities/device-type-handler-activity.ts
@@ -8,6 +8,7 @@ import { schema as parseReportSchema, ParseReport } from './parse-report';
 import { schema as sendRequestSchema, SendRequest } from './send-request';
 import { schema as setDeviceFieldsSchema, SetDeviceFields } from './set-device-fields';
 import { schema as setReportingFrequencySchema, SetReportingFrequency } from './set-reporting-frequency';
+import { schema as expectNextReportBeforeSchema, ExpectNextReportBefore } from './expect-next-report-before';
 
 type DeviceTypeHandlerActivity = DropCommand
   | IncreaseReportingCounter
@@ -16,7 +17,8 @@ type DeviceTypeHandlerActivity = DropCommand
   | ScheduleCommand
   | SendRequest
   | SetDeviceFields
-  | SetReportingFrequency;
+  | SetReportingFrequency
+  | ExpectNextReportBefore;
 
 const schema = (apiVersion: number): Joi.AlternativesSchema => Joi.alternatives().try(
   dropCommandSchema,
@@ -27,6 +29,7 @@ const schema = (apiVersion: number): Joi.AlternativesSchema => Joi.alternatives(
   sendRequestSchema,
   setDeviceFieldsSchema,
   setReportingFrequencySchema,
+  expectNextReportBeforeSchema,
 );
 
 export { schema, DeviceTypeHandlerActivity };

--- a/src/models/supplier-activities/expect-next-report-before.ts
+++ b/src/models/supplier-activities/expect-next-report-before.ts
@@ -3,13 +3,13 @@ import Joi from 'joi';
 import { schemaConstructor as supplierActivityConstructor, SupplierActivity } from './base';
 
 interface ExpectNextReportBefore extends SupplierActivity<'expectNextReportBefore'> {
-  triggerData: { before: Date };
+  triggerData: { before?: Date };
 }
 
 const schema = supplierActivityConstructor(
   'expectNextReportBefore',
   Joi.object().keys({
-    before: Joi.date().required().example('2019-12-31T15:23Z'),
+    before: Joi.date().example('2019-12-31T15:23Z'),
   }).required(),
 )
   .tag('supplierActivityExpectNextReportBefore')

--- a/src/models/supplier-activities/expect-next-report-before.ts
+++ b/src/models/supplier-activities/expect-next-report-before.ts
@@ -1,0 +1,18 @@
+import Joi from 'joi';
+
+import { schemaConstructor as supplierActivityConstructor, SupplierActivity } from './base';
+
+interface ExpectNextReportBefore extends SupplierActivity<'expectNextReportBefore'> {
+  triggerData: { before: Date };
+}
+
+const schema = supplierActivityConstructor(
+  'expectNextReportBefore',
+  Joi.object().keys({
+    before: Joi.date().required().example('2019-12-31T15:23Z'),
+  }).required(),
+)
+  .tag('supplierActivityExpectNextReportBefore')
+  .description('User defined function in the connectivity environment that sets the date, before which system will expect to receive next report of a specific device. The system uses this information to monitor connectivity of the device and raises an issue if it fails to report in time.');
+
+export { schema, ExpectNextReportBefore };

--- a/src/routes/device/link.ts
+++ b/src/routes/device/link.ts
@@ -47,6 +47,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
     device: deviceSchema.required(),
     deviceType: deviceTypeSchema.required(),
     measurementCycle: measurementCycleSchema.allow(null).required(),
+    nextReportBefore: Joi.date().allow(null).required(),
     pins: Joi.array().items(pinSchema).required().description('All ports (pins) of the location (pinGroup), as some might have an updated deviceFields property'),
   }).required(),
   right: { environment: 'SENSORS' },

--- a/src/routes/device/link.ts
+++ b/src/routes/device/link.ts
@@ -25,6 +25,7 @@ interface Response {
   device: Device;
   deviceType: DeviceType;
   measurementCycle: MeasurementCycle | null;
+  nextReportBefore: Date | null;
   pins: Pin[];
 }
 

--- a/src/routes/graph/get-edge.ts
+++ b/src/routes/graph/get-edge.ts
@@ -19,7 +19,7 @@ interface Response {
   pins: Pin[];
   pinGroups: PinGroup[];
   measurementCycles: Array<MeasurementCycle | null>;
-  nextReportBefore: Date | null;
+  nextReportBefore: Array<Date | null>;
   thresholds: {
     value: Threshold;
     quantity: Quantity;
@@ -39,7 +39,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
     pins: Joi.array().items(pinSchema).required(),
     pinGroups: Joi.array().items(pinGroupSchema(apiVersion)).required(),
     measurementCycles: Joi.array().items(measurementCycleSchema.allow(null)).required(),
-    nextReportBefore: Joi.date().allow(null).required(),
+    nextReportBefore: Joi.array().items(Joi.date().allow(null)).required(),
     thresholds: Joi.array().items(Joi.object().keys({
       value: thresholdSchema.required(),
       quantity: quantitySchema.required(),

--- a/src/routes/graph/get-edge.ts
+++ b/src/routes/graph/get-edge.ts
@@ -19,6 +19,7 @@ interface Response {
   pins: Pin[];
   pinGroups: PinGroup[];
   measurementCycles: Array<MeasurementCycle | null>;
+  nextReportBefore: Date | null;
   thresholds: {
     value: Threshold;
     quantity: Quantity;

--- a/src/routes/graph/get-edge.ts
+++ b/src/routes/graph/get-edge.ts
@@ -39,6 +39,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
     pins: Joi.array().items(pinSchema).required(),
     pinGroups: Joi.array().items(pinGroupSchema(apiVersion)).required(),
     measurementCycles: Joi.array().items(measurementCycleSchema.allow(null)).required(),
+    nextReportBefore: Joi.date().allow(null).required(),
     thresholds: Joi.array().items(Joi.object().keys({
       value: thresholdSchema.required(),
       quantity: quantitySchema.required(),

--- a/src/routes/graph/get-pin-group.ts
+++ b/src/routes/graph/get-pin-group.ts
@@ -31,6 +31,7 @@ interface Response {
     pinHashId: string | null;
   }[] | null;
   measurementCycle: MeasurementCycle | null;
+  nextReportBefore: Date | null;
   thresholds: {
     value: Threshold;
     quantity: Quantity;

--- a/src/routes/graph/get-pin-group.ts
+++ b/src/routes/graph/get-pin-group.ts
@@ -81,6 +81,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
         pinHashId: Joi.string().allow(null).default(null),
       })).required().allow(null),
       measurementCycle: measurementCycleSchema.allow(null).required(),
+      nextReportBefore: Joi.date().allow(null).required(),
       thresholds: Joi.array().items(Joi.object().keys({
         value: thresholdSchema.required(),
         quantity: quantitySchema.required(),

--- a/src/routes/graph/get-pin-group.ts
+++ b/src/routes/graph/get-pin-group.ts
@@ -81,7 +81,6 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
         pinHashId: Joi.string().allow(null).default(null),
       })).required().allow(null),
       measurementCycle: measurementCycleSchema.allow(null).required(),
-      nextReportBefore: Joi.date().allow(null).required(),
       thresholds: Joi.array().items(Joi.object().keys({
         value: thresholdSchema.required(),
         quantity: quantitySchema.required(),
@@ -97,6 +96,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptions = {
     }
 
     return base.keys({
+      nextReportBefore: Joi.date().allow(null).required(),
       grids: Joi.array().items(gridSchema).required(),
     });
   },


### PR DESCRIPTION
 * added `ExpectNextReportBefore` supplier activity
 * added `nextReportBefore` field into `device.link`, `graph.get-edge`, `graph.get-pin-group` routes