### PR TITLE
feat(pin): add pinGroupName to model

### DIFF
--- a/src/models/pin.ts
+++ b/src/models/pin.ts
@@ -4,9 +4,6 @@ import { schema as fieldsFromServerSchema, FieldsFromServer } from './fields/fie
 const schema = Joi.object().keys({
   hashId: Joi.string().required().example('e13d57'),
   pinGroupHashId: Joi.string().required().example('dao97'),
-  pinGroup: Joi.object().keys({
-    name: Joi.string().required().example('My Location'),
-  }).optional(),
   name: Joi.string().required().example('My port'),
   fields: fieldsFromServerSchema.required().example({ id: 'My port' })
     .description('The field configuration is stored in the fieldConfigurations key of the monitoring environment object'),
@@ -27,9 +24,6 @@ const schema = Joi.object().keys({
 interface Pin {
   hashId: string;
   pinGroupHashId: string;
-  pinGroup?: {
-    name: string;
-  }
   name: string;
   fields: FieldsFromServer;
   deviceFields: FieldsFromServer;

--- a/src/models/pin.ts
+++ b/src/models/pin.ts
@@ -4,6 +4,9 @@ import { schema as fieldsFromServerSchema, FieldsFromServer } from './fields/fie
 const schema = Joi.object().keys({
   hashId: Joi.string().required().example('e13d57'),
   pinGroupHashId: Joi.string().required().example('dao97'),
+  pinGroup: Joi.object().keys({
+    name: Joi.string().required().example('My Location'),
+  }).optional(),
   name: Joi.string().required().example('My port'),
   fields: fieldsFromServerSchema.required().example({ id: 'My port' })
     .description('The field configuration is stored in the fieldConfigurations key of the monitoring environment object'),
@@ -24,6 +27,9 @@ const schema = Joi.object().keys({
 interface Pin {
   hashId: string;
   pinGroupHashId: string;
+  pinGroup?: {
+    name: string;
+  }
   name: string;
   fields: FieldsFromServer;
   deviceFields: FieldsFromServer;

--- a/src/routes/graph/find-pin.ts
+++ b/src/routes/graph/find-pin.ts
@@ -4,6 +4,7 @@ import { ControllerGeneratorOptionsWithClient } from '../../comms/controller';
 import { schema as pinSchema, Pin } from '../../models/pin';
 
 import { TableQuery, EffectiveTableQuery, tableQuerySchemaGenerator } from '../../comms/table-controller';
+import { PinGroup } from '../../models/pin-group';
 
 interface Query extends TableQuery {
   includeDeleted?: boolean;
@@ -23,6 +24,7 @@ interface EffectiveRequest {
 
 interface ResponseRow {
   pin: Pin;
+  pinGroup: Pick<PinGroup, 'name'>;
 }
 
 interface Response {
@@ -43,6 +45,9 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
       .description('This is the last page if nextPageOffset is null'),
     rows: Joi.array().items(Joi.object().keys({
       pin: pinSchema.required(),
+      pinGroup: Joi.object().keys({
+        name: Joi.string().required().example('My location'),
+      }).required(),
     })).required(),
   }),
   description: 'Search through pins',


### PR DESCRIPTION
## Authors
@Arinono 

## Issues
withthegrid/platform-client#1002

Used by https://github.com/withthegrid/platform/pull/1111
Used by https://github.com/withthegrid/platform-client/pull/1038

## Implementation details

Adds a `pinGroup.name` to the model of a `pin`.

I chose to do 2 things:
- Not add more fields, because we don't need more atm
- Add the `name` in a separate object, next to `pinGroupHashId`:
  - Because I don't want to break anything using `pinGroupHashId`
  - Because I don't want to have a `pinGroupName` living with the rest of the object as it's not totally related