### PR TITLE
fix(comms): handle more axios errors kinds

### DIFF
--- a/src/comms/index.ts
+++ b/src/comms/index.ts
@@ -131,7 +131,15 @@ class Comms {
             data,
           );
         }
-        if (e.code === AxiosError.ERR_NETWORK && e.request !== undefined) {
+        const axiosNetworkErrorCodes = [
+          AxiosError.ERR_NETWORK,
+          AxiosError.ETIMEDOUT,
+          AxiosError.ECONNABORTED,
+        ];
+        const { code, request } = e;
+        if (code !== undefined
+          && request !== undefined
+          && axiosNetworkErrorCodes.includes(code)) {
           throw new CommsRequestError(
             method,
             path,


### PR DESCRIPTION
## Authors
@Arinono 

## Issues
Fixes withthegrid/platform-client#1320

## Implementation details
The `timeout exceeded` comes from `axios` in particular the `AxiosError.ETIMEDOUT` and/or `AxiosError.ECONNABORTED`. [see](https://cs.github.com/axios/axios/blob/62d8eb793eb1cfd925923ff9c5855189ced9bce1/lib/adapters/xhr.js#L158)

So I handled them as `WTG.CommsRequestError`.