### PR TITLE
feat(commands): add deleteMulti endpoint types

### DIFF
--- a/src/routes/command/deleteMulti.ts
+++ b/src/routes/command/deleteMulti.ts
@@ -8,41 +8,48 @@ interface Request {
 }
 
 type ValidResponse = {
-	hashId: string
-	deleted: true
-}
+  hashId: string;
+  deleted: true;
+};
 
 type ErrorResponse = {
-	hashId: string
-	deleted: false
-	failureReason: string
-}
+  hashId: string;
+  deleted: false;
+  failureReason: string;
+};
 
 type Response = Array<ValidResponse | ErrorResponse>;
 
 const validResponseSchema = Joi.object().keys({
-	hashId: Joi.string().required().example('ga9741s'),
-	deleted: Joi.boolean().default(true).disallow(false).example(true),
+  hashId: Joi.string().required().example('ga9741s'),
+  deleted: Joi.boolean().default(true).disallow(false).example(true),
 });
 
 const errorResponseSchema = Joi.object().keys({
-	hashId: Joi.string().required().example('ga9741s'),
-	deleted: Joi.boolean().default(false).disallow(true).example(false),
-	failureReason: Joi.string().example('Device cannot be reached in time to cancel this command.'),
+  hashId: Joi.string().required().example('ga9741s'),
+  deleted: Joi.boolean().default(false).disallow(true).example(false),
+  failureReason: Joi.string().example(
+    'Device cannot be reached in time to cancel this command.',
+  ),
 });
 
 const controllerGeneratorOptions: ControllerGeneratorOptionsWithClientAndSupplier = {
   method: 'delete',
   path: '/',
-  body: Joi.object().keys({
-    hashIds: Joi.array().items(Joi.string()).required().example(['ga9741s']),
-  }).required(),
-  response: Joi.array().items(Joi.alternatives([
-		validResponseSchema,
-		errorResponseSchema,
-	])),
+  body: Joi.object()
+    .keys({
+      hashIds: Joi.array()
+        .items(Joi.string())
+        .required()
+        .example(['ga9741s']),
+    })
+    .required(),
+  response: Joi.array().items(
+    Joi.alternatives([validResponseSchema, errorResponseSchema]),
+  ),
   right: { environment: 'SENSORS', supplier: 'ENVIRONMENT_ADMIN' },
-  description: 'Delete multiple commands. Will return an array showing which commands were deleted or not.',
+  description:
+      'Delete multiple commands. Will return an array showing which commands were deleted or not.',
 };
 
 export {

--- a/src/routes/command/deleteMulti.ts
+++ b/src/routes/command/deleteMulti.ts
@@ -1,0 +1,36 @@
+import Joi from 'joi';
+import { ControllerGeneratorOptionsWithClientAndSupplier } from '../../comms/controller';
+
+interface Request {
+  body: {
+    hashIds: string[];
+  };
+}
+
+type Response = Array<{
+  hashId: string,
+  deleted: boolean
+  reason?: string,
+}>;
+
+const controllerGeneratorOptions: ControllerGeneratorOptionsWithClientAndSupplier = {
+  method: 'delete',
+  path: '/',
+  body: Joi.object().keys({
+    hashIds: Joi.array().items(Joi.string()).required().example(['ga9741s']),
+  }).required(),
+  response: Joi.array().items(Joi.object().keys({
+    hashId: Joi.string().required().example('ga9741s'),
+    deleted: Joi.boolean().required().example(false),
+    reason: Joi.string().example('Device cannot be reached in time to cancel this command.'),
+  })),
+  right: { environment: 'SENSORS', supplier: 'ENVIRONMENT_ADMIN' },
+  description: 'Delete multiple commands. Will return an array showing which commands were deleted or not.',
+};
+
+export {
+  controllerGeneratorOptions,
+  Request,
+  Request as EffectiveRequest,
+  Response,
+};

--- a/src/routes/command/index.ts
+++ b/src/routes/command/index.ts
@@ -1,5 +1,6 @@
 import * as add from './add';
 import * as deleteRoute from './delete';
+import * as deleteMulti from './deleteMulti';
 import * as find from './find';
 import * as get from './get';
 
@@ -34,6 +35,18 @@ class CommandRoute {
       deleteRoute.Response
     >(
       deleteRoute.controllerGeneratorOptions,
+      CommandRoute.routerPath,
+      CommandRoute.auth,
+      this.comms,
+    )(parameters);
+
+  deleteMulti = (parameters: deleteMulti.Request):
+    Result<deleteMulti.EffectiveRequest, deleteMulti.Response> => controllerGenerator<
+      deleteMulti.Request,
+      deleteMulti.EffectiveRequest,
+      deleteMulti.Response
+    >(
+      deleteMulti.controllerGeneratorOptions,
       CommandRoute.routerPath,
       CommandRoute.auth,
       this.comms,

--- a/src/routes/command/routes.ts
+++ b/src/routes/command/routes.ts
@@ -1,11 +1,13 @@
 import * as add from './add';
 import * as deleteRoute from './delete';
+import * as deleteMulti from './deleteMulti';
 import * as find from './find';
 import * as get from './get';
 
 export {
   add,
   deleteRoute as delete,
+  deleteMulti,
   find,
   get,
 };


### PR DESCRIPTION
## Authors
@Arinono 

## Issues
Refs withthegrid/platform-client#473
Used by withthegrid/platform#1364 and withthegrid/platform-client#1344

## Implementation details
I chose to create a new endpoint `DELETE /command/deleteMulti` for a few reasons.

First, if I updated the `DELETE /command` to support multiple `hashIds`, I think it would have brought a some complexity that is unnecessary (to the types, the documentation, ...)

Now, onto how it could have been done, well, I'm not sure, because no one knows for sure how it's done in a REST API. There is no standard for this operation, it can be:
- DELETE /command?hashid=one&hashid=two
- DELETE /command?hashids[]=one&hashids[]=two
- DELETE /command?hashids=one,two

And all of these are a breaking change.
(as a reminder, the current single delete endpoint is `DELETE /command/{hashId}`)

If I want to avoid a breaking change AND have a single endpoint, I would need an alternative schema (current OR new). And unless I missed smth, to support both, I would need an optional `hashId` in path or an optional `hashId` in the seachParams (no matter the shape). And doing this would mean that there is no required `hashId`, so it would need extra checks in the platform, and the validation happening in the SDK would be too loose.

## Medias

### Screenshots

Here is how it look in the docs:
![Screenshot 2022-07-08 at 14 38 27](https://user-images.githubusercontent.com/10957531/177993753-72d30424-2144-49cd-9f83-5d613c36d364.png)

