### PR TITLE
fix(link-replacer): add common helper to replace link references

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:open-api-file": "ts-node -P tsconfig.cjs.json --files ./documentation/",
     "build:redoc-index-html": "redoc-cli bundle ./documentation/redoc.json --output ./docs/index.html -t ./documentation/html-template.hbs",
     "prepare": "npm run build",
-    "lint": "npm run build:cjs && eslint --ext .ts src",
+    "lint": "npm run build:cjs && eslint --ext .ts src test",
     "release": "ts-node -P tsconfig.cjs.json release/"
   },
   "author": "Rob Everhardt <rob@withthegrid.com>",

--- a/src/commons/index.ts
+++ b/src/commons/index.ts
@@ -1,0 +1,1 @@
+export * from './link-replacer';

--- a/src/commons/link-replacer.ts
+++ b/src/commons/link-replacer.ts
@@ -1,5 +1,5 @@
 const issue = ['issue'] as const;
-const report = ['report', 'rapport', 'meetrapport'] as const;
+const report = ['condition report', 'report', 'rapport', 'meetrapport'] as const;
 const command = ['command', 'opdracht'] as const;
 
 // the regexp have been verified on https://makenowjust-labs.github.io/recheck

--- a/src/commons/link-replacer.ts
+++ b/src/commons/link-replacer.ts
@@ -1,0 +1,51 @@
+const issue = ['issue'] as const;
+const report = ['report', 'rapport', 'meetrapport'] as const;
+const command = ['command', 'opdracht'] as const;
+
+// the regexp have been verified on https://makenowjust-labs.github.io/recheck
+const matchers = [
+  [
+    'issues',
+    new RegExp(`(?<key>${issue.join('|')}) #(?<hashid>[\\w\\d]{6,})`, 'gi'),
+  ],
+  [
+    'reports',
+    new RegExp(`(?<key>${report.join('|')}) #(?<hashid>[\\w\\d]{6,})`, 'gi'),
+  ],
+  [
+    'commands',
+    new RegExp(`(?<key>${command.join('|')}) #(?<hashid>[\\w\\d]{6,})`, 'gi'),
+  ],
+];
+
+/**
+ * Replace the references in the text with the correct links.
+ * @param {string} environmentHashId The hashid of the environment.
+ * @param {string} text The text to replace.
+ * @returns {string} The text with the correct links.
+ * @example
+ * ```ts
+ * const replaced = replaceLinks('eyr9dr', 'issue #eyr9dr')
+ * console.log(replaced)
+ * // => '<a href="/issues/eyr9dr">issue #eyr9dr</a>'
+ * ```
+ */
+export const replaceLinks = (
+  environmentHashId: string,
+  text: string,
+): string => {
+  for (let i = 0, len = matchers.length; i < len; i += 1) {
+    const [entity, regex] = matchers[i];
+    const matches = text.match(regex);
+    if (matches !== null) {
+      return text.replace(regex, (match, _key, hashid) => {
+        const url = `#/e/${environmentHashId}/${entity}/${hashid}`;
+        return `<a href="${url}">${match.toLowerCase()}</a>`;
+      });
+    }
+  }
+
+  return text;
+};
+
+export default replaceLinks;

--- a/src/commons/link-replacer.ts
+++ b/src/commons/link-replacer.ts
@@ -38,7 +38,7 @@ export const replaceLinks = (
     const [entity, regex] = matchers[i];
     const matches = text.match(regex);
     if (matches !== null) {
-      return text.replace(regex, (match, _key, hashid) => {
+      text = text.replaceAll(regex, (match, _key, hashid) => {
         const url = `#/e/${environmentHashId}/${entity}/${hashid}`;
         return `<a href="${url}">${match.toLowerCase()}</a>`;
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import Routes, * as IndividualRoutes from './routes';
 
 import * as models from './models';
 import * as routes from './routes/routes';
+import * as commons from './commons';
 
 import { Response as MachineLoginResponse } from './routes/authentication/machine-login';
 
@@ -72,6 +73,7 @@ export { default as errors } from './errors';
 export {
   routes,
   models,
+  commons,
   Routes,
   IndividualRoutes,
   Joi,

--- a/test/link-replacer.test.ts
+++ b/test/link-replacer.test.ts
@@ -1,0 +1,53 @@
+import { replaceLinks } from '../src/commons/link-replacer';
+
+const DUMMY_ENV_HASHID = 'dummy-env-hashid';
+
+const a = (link: string, text: string) => `<a href="#/e/${DUMMY_ENV_HASHID}/${link}">${text}</a>`;
+
+describe('link replacement', () => {
+  describe('given the text input matches no link', () => {
+    test('then nothing is replaced', () => {
+      // arrange
+      const input = 'The device has not been online for more than 3 days and has missed 2 consecutive condition reports.';
+
+      // act
+      const replaced = replaceLinks(DUMMY_ENV_HASHID, input);
+
+      // assert
+      expect(replaced).toEqual(input);
+    });
+  });
+
+  describe('given the text matches a link reference', () => {
+    describe('then the link is replaced with an anchor tag', () => {
+      test.each([
+        // issues
+        ['issue #eyr9dr', a('issues/eyr9dr', 'issue #eyr9dr')],
+        [' issue #eyr9dr ', ` ${a('issues/eyr9dr', 'issue #eyr9dr')} `],
+        ['Issue #eyr9dr', a('issues/eyr9dr', 'issue #eyr9dr')],
+        [' Issue #eyr9dr ', ` ${a('issues/eyr9dr', 'issue #eyr9dr')} `],
+
+        // reports
+        ['report #eyr9dr', a('reports/eyr9dr', 'report #eyr9dr')],
+        ['Report #eyr9dr', a('reports/eyr9dr', 'report #eyr9dr')],
+        [
+          'condition report #eyr9dr',
+          `condition ${a('reports/eyr9dr', 'report #eyr9dr')}`,
+        ],
+        ['rapport #eyr9dr', a('reports/eyr9dr', 'rapport #eyr9dr')],
+        ['meetrapport #eyr9dr', a('reports/eyr9dr', 'meetrapport #eyr9dr')],
+
+        // commands
+        ['command #eyr9dr', a('commands/eyr9dr', 'command #eyr9dr')],
+        ['Command #eyr9dr', a('commands/eyr9dr', 'command #eyr9dr')],
+        ['opdracht #eyr9dr', a('commands/eyr9dr', 'opdracht #eyr9dr')],
+      ])('(%s) -> (%s)', (input, expected) => {
+        // act
+        const replaced = replaceLinks(DUMMY_ENV_HASHID, input);
+
+        // assert
+        expect(replaced).toEqual(expected);
+      });
+    });
+  });
+});

--- a/test/link-replacer.test.ts
+++ b/test/link-replacer.test.ts
@@ -32,7 +32,7 @@ describe('link replacement', () => {
         ['Report #eyr9dr', a('reports/eyr9dr', 'report #eyr9dr')],
         [
           'condition report #eyr9dr',
-          `condition ${a('reports/eyr9dr', 'report #eyr9dr')}`,
+          `${a('reports/eyr9dr', 'condition report #eyr9dr')}`,
         ],
         ['rapport #eyr9dr', a('reports/eyr9dr', 'rapport #eyr9dr')],
         ['meetrapport #eyr9dr', a('reports/eyr9dr', 'meetrapport #eyr9dr')],

--- a/test/link-replacer.test.ts
+++ b/test/link-replacer.test.ts
@@ -41,6 +41,11 @@ describe('link replacement', () => {
         ['command #eyr9dr', a('commands/eyr9dr', 'command #eyr9dr')],
         ['Command #eyr9dr', a('commands/eyr9dr', 'command #eyr9dr')],
         ['opdracht #eyr9dr', a('commands/eyr9dr', 'opdracht #eyr9dr')],
+
+        // multi and combined
+        ['issue #eyr9dr and report #eyr9dr', `${a('issues/eyr9dr', 'issue #eyr9dr')} and ${a('reports/eyr9dr', 'report #eyr9dr')}`],
+        ['issue #eyr9dr and command #eyr9dr', `${a('issues/eyr9dr', 'issue #eyr9dr')} and ${a('commands/eyr9dr', 'command #eyr9dr')}`],
+        ['issue #eyr9dr and command #eyr9dr and report #eyr9dr', `${a('issues/eyr9dr', 'issue #eyr9dr')} and ${a('commands/eyr9dr', 'command #eyr9dr')} and ${a('reports/eyr9dr', 'report #eyr9dr')}`],
       ])('(%s) -> (%s)', (input, expected) => {
         // act
         const replaced = replaceLinks(DUMMY_ENV_HASHID, input);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,9 @@
         "src/types/*"
       ]
     },
+    "lib": [
+      "ES2021.String"
+    ]
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
## Authors
@Arinono 

## Issues
refs withthegrid/platform-client#1368

## Implementation details

Mostly taking what was on both the client and the platform, refactoring it a bit and adding unit tests.

<img width="1800" alt="Screenshot 2022-07-15 at 19 46 06" src="https://user-images.githubusercontent.com/10957531/179281731-ca4e8db3-e0c7-4ecc-87de-a091fc18eb15.png">
