### PR TITLE
feat: add theme to update and model

### DIFF
--- a/src/commons/theme.ts
+++ b/src/commons/theme.ts
@@ -16,7 +16,6 @@ const colorsSchema = Joi.object().keys({
  * @internal
  */
 export const themeSchema = Joi.object().keys({
-  name: Joi.string().example('My new theme').required(),
   light: colorsSchema.required(),
   dark: colorsSchema.optional(),
 });
@@ -36,7 +35,6 @@ type Colors = {
  * @internal
  */
 export type Theme = {
-  name: string;
   light: Colors;
   dark?: Colors;
 };

--- a/src/commons/theme.ts
+++ b/src/commons/theme.ts
@@ -1,14 +1,15 @@
 import Joi from 'joi';
 
-const colorSchema = Joi.object().keys({
-  primary: Joi.string().required().example('#ff00ff'),
-  secondary: Joi.string().required().example('#ff00ff'),
-  accent: Joi.string().required().example('#ff00ff'),
-  error: Joi.string().required().example('#ff00ff'),
-  warning: Joi.string().required().example('#ff00ff'),
-  info: Joi.string().required().example('#ff00ff'),
-  success: Joi.string().required().example('#ff00ff'),
-  neutral: Joi.string().required().example('#ff00ff'),
+const colorSchema = Joi.string().required().example('#ff00ff').regex(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+const colorsSchema = Joi.object().keys({
+  primary: colorSchema,
+  secondary: colorSchema,
+  accent: colorSchema,
+  error: colorSchema,
+  warning: colorSchema,
+  info: colorSchema,
+  success: colorSchema,
+  neutral: colorSchema,
 });
 
 /**
@@ -16,8 +17,8 @@ const colorSchema = Joi.object().keys({
  */
 export const themeSchema = Joi.object().keys({
   name: Joi.string().example('My new theme').required(),
-  light: colorSchema.required(),
-  dark: colorSchema.optional(),
+  light: colorsSchema.required(),
+  dark: colorsSchema.optional(),
 });
 
 type Colors = {

--- a/src/commons/theme.ts
+++ b/src/commons/theme.ts
@@ -1,0 +1,41 @@
+import Joi from 'joi';
+
+const colorSchema = Joi.object().keys({
+  primary: Joi.string().required().example('#ff00ff'),
+  secondary: Joi.string().required().example('#ff00ff'),
+  accent: Joi.string().required().example('#ff00ff'),
+  error: Joi.string().required().example('#ff00ff'),
+  warning: Joi.string().required().example('#ff00ff'),
+  info: Joi.string().required().example('#ff00ff'),
+  success: Joi.string().required().example('#ff00ff'),
+  neutral: Joi.string().required().example('#ff00ff'),
+});
+
+/**
+ * @internal
+ */
+export const themeSchema = Joi.object().keys({
+  name: Joi.string().example('My new theme').required(),
+  light: colorSchema.required(),
+  dark: colorSchema.optional(),
+});
+
+type Colors = {
+  primary: string;
+  secondary: string;
+  accent: string;
+  error: string;
+  warning: string;
+  info: string;
+  success: string;
+  neutral: string;
+};
+
+/**
+ * @internal
+ */
+export type Theme = {
+  name: string;
+  light: Colors;
+  dark?: Colors;
+};

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -3,6 +3,7 @@ import Joi from 'joi';
 import { schema as baseFieldConfigurationSchema, BaseFieldConfiguration } from './fields/base-field-configuration';
 import { Locale, schema as localeSchema } from './locale';
 import { MapLayer, schema as mapLayerSchema } from './map-layer';
+import { themeSchema, Theme } from '../commons/theme';
 
 const schema = (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
   hashId: Joi.string().required().example('f1a4w1'),
@@ -33,6 +34,7 @@ const schema = (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
     .max(9999),
   enforceTwoFactorAuthentication: Joi.boolean().required().example(false)
     .description('Determines whether users need to have two factor authentication enabled in order to access this environment.'),
+  theme: themeSchema.allow(null),
   expiresAt: Joi.date().allow(null).required().example(null),
   createdAt: Joi.date().required().example('2019-12-31T15:23Z'),
 })
@@ -59,6 +61,7 @@ interface Environment {
   defaultGraphRange: string;
   measurementsExpirationDays: number;
   enforceTwoFactorAuthentication: boolean;
+  theme: Theme | null;
   expiresAt: Date | null;
   createdAt: Date;
 }

--- a/src/models/supplier.ts
+++ b/src/models/supplier.ts
@@ -1,10 +1,12 @@
 import Joi from 'joi';
+import { Theme, themeSchema } from '../commons/theme';
 
 const schema = Joi.object().keys({
   hashId: Joi.string().required().example('f1a4w1'),
   name: Joi.string().required().example('My connectivity environment'),
   enforceTwoFactorAuthentication: Joi.boolean().required().example(false)
     .description('Determines whether users need to have two factor authentication enabled in order to access this environment.'),
+  theme: themeSchema.allow(null),
   createdAt: Joi.date().required().example('2019-12-31T15:23Z'),
 })
   .tag('supplier')
@@ -15,6 +17,7 @@ interface Supplier {
   hashId: string;
   name: string;
   enforceTwoFactorAuthentication: boolean;
+  theme: Theme | null;
   createdAt: Date;
 }
 

--- a/src/routes/environment/update.ts
+++ b/src/routes/environment/update.ts
@@ -8,6 +8,7 @@ import {
 import { schema as environmentSchema, Environment } from '../../models/environment';
 import { Locale, schema as localeSchema } from '../../models/locale';
 import { MapLayer, schema as mapLayerSchema } from '../../models/map-layer';
+import { themeSchema, Theme } from '../../commons/theme';
 
 interface Request {
   body: {
@@ -24,6 +25,7 @@ interface Request {
     defaultGraphRange?: string;
     measurementsExpirationDays?: number;
     enforceTwoFactorAuthentication?: boolean;
+    theme: Theme | null;
   };
 }
 
@@ -55,6 +57,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
         .max(9999),
       enforceTwoFactorAuthentication: Joi.boolean().example(false)
         .description('Describes if users need to have two factor authentication enabled in order to access this environment.'),
+      theme: themeSchema.allow(null),
     }).required();
   },
   right: { environment: 'ENVIRONMENT_ADMIN' },

--- a/src/routes/supplier/update.ts
+++ b/src/routes/supplier/update.ts
@@ -1,10 +1,12 @@
 import Joi from 'joi';
 import { ControllerGeneratorOptionsWithSupplier } from '../../comms/controller';
+import { Theme, themeSchema } from '../../commons/theme';
 
 interface Request {
   body: {
     name?: string;
     enforceTwoFactorAuthentication?: boolean;
+    theme: Theme | null;
   };
 }
 
@@ -17,6 +19,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
     name: Joi.string().example('My connectivity environment'),
     enforceTwoFactorAuthentication: Joi.boolean().example(false)
       .description('Describes if users need to have two factor authentication enabled in order to access this environment.'),
+    theme: themeSchema.allow(null),
   }).required(),
   right: { supplier: 'ENVIRONMENT_ADMIN' },
 };


### PR DESCRIPTION
## Authors
@Arinono 

## Issues
refs withthegrid/platform#1324
Used by withthegrid/platform#1445
Used by withthegrid/platform-client#1392

## Implementation details

Very simple schema for the theme on the 2 kinds of environments.
I did account for `dark` theme even if it's mostly ignored/skipped everywhere. I just wanted to avoid breaking changes in the future if we want to add support for `dark` themes. And it seems pretty safe, since it can only be the same things as the `light` theme