### PR TITLE
feat(command): add createdByUserName to get response

### DIFF
--- a/src/routes/command/get.ts
+++ b/src/routes/command/get.ts
@@ -13,6 +13,7 @@ interface Request {
 interface Response {
   command: Command;
   commandType: CommandType;
+  createdByUserName?: string;
 }
 
 const controllerGeneratorOptions: ControllerGeneratorOptionsWithClientAndSupplier = {
@@ -25,6 +26,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClientAndSupplie
   response: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
     command: commandSchema.required(),
     commandType: commandTypeSchema(apiVersion).required(),
+    createdByUserName: Joi.string().example('John Doe'),
   }).required(),
   description: 'Get a specific command identified by its hashId',
 };

--- a/src/routes/issue-trigger-rule/get.ts
+++ b/src/routes/issue-trigger-rule/get.ts
@@ -23,7 +23,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
   right: { environment: 'READ' },
   response: (apiVersion: number) => Joi.object().keys({
     issueTriggerRule: issueTriggerRuleSchema,
-    deviceType: deviceTypeSchema(apiVersion).optional(),
+    deviceType: deviceTypeSchema(apiVersion),
   }),
   description: 'Gets a specific issue trigger rule by its priorityLevel and/or deviceTypeHashId.',
 };


### PR DESCRIPTION
Refs https://github.com/withthegrid/platform-client/issues/1076
Is required by:  https://github.com/withthegrid/platform/pull/1450

- add createdByUserName field on the Response of get command


![image](https://user-images.githubusercontent.com/72932961/183431589-00670b4f-4eaa-46f2-a0ef-d116bf889edf.png)

_The fourth point from the task was discarded, discussed with @everhardt .
As a nice to have good to add it to the audit log of a location aswell: https://app.withthegrid.com/#/e/xd2rd4/environment/audit-log?search=objectType%3ApinGroup%20objectHashId%3Ay33m4r_

