### PR TITLE
Fix platform client 1432 sort edges by proximity

### DIFF
--- a/src/routes/graph/find-edge.ts
+++ b/src/routes/graph/find-edge.ts
@@ -6,7 +6,7 @@ import { schema as edgeSchema, Edge } from '../../models/edge';
 import { TableQuery, EffectiveTableQuery, tableQuerySchemaGenerator } from '../../comms/table-controller';
 
 interface Query extends TableQuery {
-  location?: { latitude: number, longitude: number},
+  coordinates?: [number, number],
   includeDeleted?: boolean;
   boundingBox?: [number, number, number, number];
 }
@@ -16,7 +16,7 @@ type Request = {
 } | undefined;
 
 interface EffectiveQuery extends EffectiveTableQuery {
-  location?: { latitude: number, longitude: number},
+  coordinates?: [number, number],
   includeDeleted: boolean;
   boundingBox?: [number, number, number, number];
 }
@@ -39,10 +39,12 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
   path: '/edge',
   query: tableQuerySchemaGenerator(Joi.string().valid('hashId', 'name', 'proximity').default('hashId'))
     .keys({
-      location: Joi.object().keys({
-        latitude: Joi.number().required(),
-        longitude: Joi.number().required(),
-      }),
+      coordinates: Joi.array().length(2).items(
+        Joi.number().min(-180).max(180).required(),
+        Joi.number().min(-90).max(90).required(),
+      )
+        .example([4.884707950517225, 52.37502141913572])
+        .description('[lon, lat] in WGS84'),
       includeDeleted: Joi.boolean().default(false),
       boundingBox: Joi.array()
         .items(Joi.number())

--- a/src/routes/graph/find-edge.ts
+++ b/src/routes/graph/find-edge.ts
@@ -6,6 +6,7 @@ import { schema as edgeSchema, Edge } from '../../models/edge';
 import { TableQuery, EffectiveTableQuery, tableQuerySchemaGenerator } from '../../comms/table-controller';
 
 interface Query extends TableQuery {
+  location?: { latitude: number, longitude: number},
   includeDeleted?: boolean;
   boundingBox?: [number, number, number, number];
 }
@@ -15,6 +16,7 @@ type Request = {
 } | undefined;
 
 interface EffectiveQuery extends EffectiveTableQuery {
+  location?: { latitude: number, longitude: number},
   includeDeleted: boolean;
   boundingBox?: [number, number, number, number];
 }
@@ -35,8 +37,12 @@ interface Response {
 const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
   method: 'get',
   path: '/edge',
-  query: tableQuerySchemaGenerator(Joi.string().valid('hashId', 'name').default('hashId'))
+  query: tableQuerySchemaGenerator(Joi.string().valid('hashId', 'name', 'proximity').default('hashId'))
     .keys({
+      location: Joi.object().keys({
+        latitude: Joi.number().required(),
+        longitude: Joi.number().required(),
+      }),
       includeDeleted: Joi.boolean().default(false),
       boundingBox: Joi.array()
         .items(Joi.number())


### PR DESCRIPTION
refs https://github.com/withthegrid/platform-client/issues/1432

is required by: 
https://github.com/withthegrid/platform-client/pull/1456
https://github.com/withthegrid/platform/pull/1467

- add a location query param and a sortBy option "proximity"
- display lines sorted by the distance to the location coordinates provided
![image](https://user-images.githubusercontent.com/72932961/184153787-a7c84a10-f614-4024-9b67-aa8375868eae.png)
