### PR TITLE
fix(quantity): add several name length limits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import * as commons from './commons';
 
 import { Response as MachineLoginResponse } from './routes/authentication/machine-login';
 
-const apiVersion = 8;
+const apiVersion = 9;
 
 class PlatformSdk {
   protected comms: Comms;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import * as commons from './commons';
 
 import { Response as MachineLoginResponse } from './routes/authentication/machine-login';
 
-const apiVersion = 9;
+const apiVersion = 8;
 
 class PlatformSdk {
   protected comms: Comms;

--- a/src/models/command-type.ts
+++ b/src/models/command-type.ts
@@ -1,11 +1,11 @@
 import Joi from 'joi';
 
 import { schema as baseFieldConfigurationSchema, BaseFieldConfiguration } from './fields/base-field-configuration';
-import { stringBeforeV7ElseStringOrTranslationSchema, StringOrTranslations } from './string-or-translations';
+import { versionedStringOrStringOrTranslationSchema, StringOrTranslations } from './string-or-translations';
 
 const schema = (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
   hashId: Joi.string().required().example('x18a92'),
-  name: stringBeforeV7ElseStringOrTranslationSchema(apiVersion).required().example('Measurement cycle'),
+  name: versionedStringOrStringOrTranslationSchema(apiVersion).required().example('Measurement cycle'),
   start: Joi.string().valid('required', 'optional', 'disabled').required().example('required')
     .description('\'required\': user must provide command.startAt. \'optional\': user can provide command.startAt or a delay for the command to start after it is sent to the device. \'disabled\': user cannot provide command.startAt nor a delay.'),
   end: Joi.string().valid('required', 'optional', 'disabled').required().example('disabled')

--- a/src/models/device-type.ts
+++ b/src/models/device-type.ts
@@ -1,13 +1,13 @@
 import Joi from 'joi';
 import { schema as baseFieldConfigurationSchema, BaseFieldConfiguration } from './fields/base-field-configuration';
 import {
-  stringBeforeV7ElseStringOrTranslationSchema,
+  versionedStringOrStringOrTranslationSchema,
   StringOrTranslations,
 } from './string-or-translations';
 
 const schema = (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
   hashId: Joi.string().required().example('wasd2'),
-  name: stringBeforeV7ElseStringOrTranslationSchema(apiVersion).required().example('Cathodic protection device'),
+  name: versionedStringOrStringOrTranslationSchema(apiVersion).required().example('Cathodic protection device'),
   fieldConfigurations: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required()
     .description('See the chapter on open fields on how to use this'),
   pinGroupFieldConfigurations: Joi.array()
@@ -15,12 +15,12 @@ const schema = (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
     .required()
     .description('Defines deviceFields on the location (pinGroup) the device is connected to. Can be used in report type functions. See the chapter on open fields on how to use this'),
   channels: Joi.array().items(Joi.object().keys({
-    name: stringBeforeV7ElseStringOrTranslationSchema(apiVersion).required().example('Red wire'),
+    name: versionedStringOrStringOrTranslationSchema(apiVersion).required().example('Red wire'),
     pinFieldConfigurations: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required()
       .description('Defines deviceFields on the pin the channel is connected to. Can be used in report type functions. See the chapter on open fields on how to use this'),
-    defaultPinName: stringBeforeV7ElseStringOrTranslationSchema(apiVersion).example('Anode').description('If undefined, the channel cannot be linked to a pin'),
+    defaultPinName: versionedStringOrStringOrTranslationSchema(apiVersion).example('Anode').description('If undefined, the channel cannot be linked to a pin'),
     charts: Joi.array().items(Joi.object().keys({
-      title: stringBeforeV7ElseStringOrTranslationSchema(apiVersion).required().allow(null).example('Red wire charts'),
+      title: versionedStringOrStringOrTranslationSchema(apiVersion).required().allow(null).example('Red wire charts'),
       series: Joi.array().items(Joi.object().keys({
         quantityHashId: Joi.string().example('x18a92').required(),
         color: Joi.string().example('#ff00ff').allow(null)
@@ -29,7 +29,7 @@ const schema = (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
     })).required(),
   })).required(),
   charts: Joi.array().items(Joi.object().keys({
-    title: stringBeforeV7ElseStringOrTranslationSchema(apiVersion).required().allow(null).example('Cathodic protection charts'),
+    title: versionedStringOrStringOrTranslationSchema(apiVersion).required().allow(null).example('Cathodic protection charts'),
     series: Joi.array().items(Joi.object().keys({
       channelIndex: Joi.number().integer().example(0).required(),
       quantityHashId: Joi.string().example('x18a92').required(),

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -7,7 +7,7 @@ import { themeSchema, Theme } from '../commons/theme';
 
 const schema = (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
   hashId: Joi.string().required().example('f1a4w1'),
-  name: Joi.string().required().example('My monitoring environment'),
+  name: Joi.string().required().example('My monitoring environment').max(255),
   mapLayers: Joi.array().items(mapLayerSchema).min(1).required(),
   boundingBox: Joi.object().keys({
     type: Joi.string().valid('LineString').required().example('LineString'),

--- a/src/models/fields/base-field-configuration.ts
+++ b/src/models/fields/base-field-configuration.ts
@@ -7,7 +7,7 @@ import {
 
 const commonBaseFieldConfigurationSchema = Joi.object().keys({
   key: Joi.string().pattern(/^[a-z][a-zA-Z\d]*$/).required().example('id'),
-  name: stringOrTranslationsSchema.required(),
+  name: stringOrTranslationsSchema().required(),
   showIf: Joi.object().keys({
     key: Joi.string().required(),
     value: Joi.alternatives().try(
@@ -16,12 +16,14 @@ const commonBaseFieldConfigurationSchema = Joi.object().keys({
       Joi.boolean().strict(),
     ).required(),
   }).description('Show this field if other field with provided key is set to provided value. Referenced field must exists already'),
-  hint: stringOrTranslationsSchema.allow('').description('As shown near the input field'),
+  hint: stringOrTranslationsSchema().allow('').description('As shown near the input field'),
 });
 
 const prefixesMixin = {
-  prefix: stringOrTranslationsSchema.description('Not available for inputTypes \'radio\', \'switch\', \'checkbox\', \'pinHashId\', \'pinGroupHashId\', \'file\' and \'files\''),
-  suffix: stringOrTranslationsSchema.description('Not available for inputTypes \'radio\', \'switch\', \'checkbox\', \'pinHashId\', \'pinGroupHashId\', \'file\' and \'files\''),
+  prefix: stringOrTranslationsSchema()
+    .description('Not available for inputTypes \'radio\', \'switch\', \'checkbox\', \'pinHashId\', \'pinGroupHashId\', \'file\' and \'files\''),
+  suffix: stringOrTranslationsSchema()
+    .description('Not available for inputTypes \'radio\', \'switch\', \'checkbox\', \'pinHashId\', \'pinGroupHashId\', \'file\' and \'files\''),
 };
 
 const schema = (apiVersion: number): Joi.AlternativesSchema => {
@@ -68,7 +70,7 @@ const schema = (apiVersion: number): Joi.AlternativesSchema => {
       type: Joi.string().valid('string').default('string'),
       defaultValue: Joi.string().allow(''),
       valueOptions: Joi.array().min(1).items(Joi.object().keys({
-        text: stringOrTranslationsSchema.required(),
+        text: stringOrTranslationsSchema().required(),
         value: Joi.string().allow('').required(),
       })).required(),
       inputType: Joi.string().valid('select').default('select'),
@@ -78,7 +80,7 @@ const schema = (apiVersion: number): Joi.AlternativesSchema => {
       type: Joi.string().valid('string').default('string'),
       ...deprecatedDefaultValue,
       valueOptions: Joi.array().min(1).items(Joi.object().keys({
-        text: stringOrTranslationsSchema.required(),
+        text: stringOrTranslationsSchema().required(),
         value: Joi.string().allow('').required(),
       })).required(),
       inputType: Joi.string().valid('radio').required(),
@@ -109,7 +111,7 @@ const schema = (apiVersion: number): Joi.AlternativesSchema => {
       type: Joi.string().valid('number').default('number'),
       defaultValue: Joi.number(),
       valueOptions: Joi.array().min(1).items(Joi.object().keys({
-        text: stringOrTranslationsSchema.required(),
+        text: stringOrTranslationsSchema().required(),
         value: Joi.number().required(),
       })).required(),
       inputType: Joi.string().valid('select').default('select'),
@@ -120,7 +122,7 @@ const schema = (apiVersion: number): Joi.AlternativesSchema => {
       type: Joi.string().valid('integer').required(),
       defaultValue: Joi.number().integer(),
       valueOptions: Joi.array().min(1).items(Joi.object().keys({
-        text: stringOrTranslationsSchema.required(),
+        text: stringOrTranslationsSchema().required(),
         value: Joi.number().integer().required(),
       })).required(),
       inputType: Joi.string().valid('select').default('select'),
@@ -130,7 +132,7 @@ const schema = (apiVersion: number): Joi.AlternativesSchema => {
       type: Joi.string().valid('number').default('number'),
       ...deprecatedDefaultValue,
       valueOptions: Joi.array().min(1).items(Joi.object().keys({
-        text: stringOrTranslationsSchema.required(),
+        text: stringOrTranslationsSchema().required(),
         value: Joi.number().required(),
       })).required(),
       inputType: Joi.string().valid('radio').required(),
@@ -140,7 +142,7 @@ const schema = (apiVersion: number): Joi.AlternativesSchema => {
       type: Joi.string().valid('integer').required(),
       ...deprecatedDefaultValue,
       valueOptions: Joi.array().min(1).items(Joi.object().keys({
-        text: stringOrTranslationsSchema.required(),
+        text: stringOrTranslationsSchema().required(),
         value: Joi.number().integer().required(),
       })).required(),
       inputType: Joi.string().valid('radio').required(),
@@ -158,7 +160,7 @@ const schema = (apiVersion: number): Joi.AlternativesSchema => {
       type: Joi.string().valid('boolean').default('boolean'),
       defaultValue: Joi.boolean(),
       valueOptions: Joi.array().min(1).items(Joi.object().keys({
-        text: stringOrTranslationsSchema.required(),
+        text: stringOrTranslationsSchema().required(),
         value: Joi.boolean().required(),
       })).required(),
       inputType: Joi.string().valid('select').default('select'),
@@ -168,7 +170,7 @@ const schema = (apiVersion: number): Joi.AlternativesSchema => {
       type: Joi.string().valid('boolean').default('boolean'),
       ...deprecatedDefaultValue,
       valueOptions: Joi.array().min(1).items(Joi.object().keys({
-        text: stringOrTranslationsSchema.required(),
+        text: stringOrTranslationsSchema().required(),
         value: Joi.boolean().required(),
       })).required(),
       inputType: Joi.string().valid('radio').required(),

--- a/src/models/measurement-filter.ts
+++ b/src/models/measurement-filter.ts
@@ -2,8 +2,13 @@ import Joi from 'joi';
 
 const schema = Joi.object().keys({
   hashId: Joi.string().required().example('k8gh3'),
-  name: Joi.string().required().example('North'),
-  description: Joi.string().required().allow('').example('Temperatures in the North'),
+  name: Joi.string().required().example('North').max(100),
+  description: Joi
+    .string()
+    .required()
+    .allow('')
+    .example('Temperatures in the North')
+    .max(255),
   period: Joi.alternatives().try(
     Joi.string().valid('lastMonth', 'lastQuarter', 'lastYear').required().example('lastMonth'),
     Joi.object().keys({

--- a/src/models/quantity.ts
+++ b/src/models/quantity.ts
@@ -1,13 +1,13 @@
 import Joi from 'joi';
 import { schema as siNumberSchema, SiNumber } from './si-number';
 import {
-  stringBeforeV7ElseStringOrTranslationSchema,
+  versionedStringOrStringOrTranslationSchema,
   StringOrTranslations,
 } from './string-or-translations';
 
 const schema = (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
   hashId: Joi.string().required().example('sajia1'),
-  name: stringBeforeV7ElseStringOrTranslationSchema(apiVersion).required().example('Temperature'),
+  name: versionedStringOrStringOrTranslationSchema(apiVersion).required().example('Temperature'),
   color: Joi.string().required().example('#ff00ff'),
   unit: (
     apiVersion >= 8

--- a/src/models/quantity.ts
+++ b/src/models/quantity.ts
@@ -14,6 +14,7 @@ const schema = (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
       ? Joi.string().allow(null).default(null)
       : Joi.string().required()
   ).example('K')
+    .max(10)
     .description('Will be displayed with an SI-prefix (eg. k or M) if relevant'),
   defaultOrderOfMagnitude: Joi.number().integer().min(-128).max(127)
     .default(0)

--- a/src/models/string-or-translations.ts
+++ b/src/models/string-or-translations.ts
@@ -2,12 +2,23 @@ import Joi from 'joi';
 import { schema as translationsSchema, Translations } from './translations';
 import { Locale } from './locale';
 
-const schema = (limit = 9999): Joi.AnySchema => Joi.alternatives().try(
-  Joi.string().example('untranslated string').meta({ className: 'untranslatedString' }).max(limit),
-  translationsSchema(limit),
-)
-  .tag('stringOrTranslations')
-  .meta({ className: 'stringOrTranslations' });
+const schema = (limit?: number): Joi.AnySchema => {
+  if (limit !== undefined) {
+    return Joi.alternatives().try(
+      Joi.string().example('untranslated string').meta({ className: 'untranslatedString' }).max(limit),
+      translationsSchema(limit),
+    )
+      .tag('stringOrTranslations')
+      .meta({ className: 'stringOrTranslations' });
+  }
+
+  return Joi.alternatives().try(
+    Joi.string().example('untranslated string').meta({ className: 'untranslatedString' }),
+    translationsSchema(),
+  )
+    .tag('stringOrTranslations')
+    .meta({ className: 'stringOrTranslations' });
+};
 
 const versionedStringOrStringOrTranslationSchema = (apiVersion: number): Joi.AnySchema => {
   // [min, max, schema]

--- a/src/models/string-or-translations.ts
+++ b/src/models/string-or-translations.ts
@@ -24,7 +24,7 @@ const versionedStringOrStringOrTranslationSchema = (apiVersion: number): Joi.Any
   // [min, max, schema]
   // range being [x;y)
   const ranges: [number, number, Joi.AnySchema][] = [
-    [9, 9999, schema(255)],
+    [9, Infinity, schema(255)],
     [8, 9, schema()],
     [0, 7, Joi.string()],
   ];

--- a/src/models/string-or-translations.ts
+++ b/src/models/string-or-translations.ts
@@ -21,18 +21,8 @@ const schema = (limit?: number): Joi.AnySchema => {
 };
 
 const versionedStringOrStringOrTranslationSchema = (apiVersion: number): Joi.AnySchema => {
-  // [min, max, schema]
-  // range being [x;y)
-  const ranges: [number, number, Joi.AnySchema][] = [
-    [9, Infinity, schema(255)],
-    [8, 9, schema()],
-    [0, 7, Joi.string()],
-  ];
-  for (let i = 0, len = ranges.length; i < len; i += 1) {
-    const [min, max, appliedSchema] = ranges[i];
-    if (apiVersion >= min && apiVersion < max) {
-      return appliedSchema;
-    }
+  if (apiVersion <= 6) {
+    return Joi.string();
   }
   return schema(255);
 };

--- a/src/models/supplier-report-type.ts
+++ b/src/models/supplier-report-type.ts
@@ -2,13 +2,13 @@ import Joi from 'joi';
 
 import { schema as baseFieldConfigurationSchema, BaseFieldConfiguration } from './fields/base-field-configuration';
 import {
-  stringBeforeV7ElseStringOrTranslationSchema,
+  versionedStringOrStringOrTranslationSchema,
   StringOrTranslations,
 } from './string-or-translations';
 
 const schema = (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
   hashId: Joi.string().required().example('l19a7s'),
-  name: stringBeforeV7ElseStringOrTranslationSchema(apiVersion).required().example('Temperature and inclination'),
+  name: versionedStringOrStringOrTranslationSchema(apiVersion).required().example('Temperature and inclination'),
   fieldConfigurations: Joi.object().keys({
     pinGroup: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required(),
     pin: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required(),

--- a/src/models/supplier-webhook.ts
+++ b/src/models/supplier-webhook.ts
@@ -12,7 +12,7 @@ const identifierExample = `function (command) {
 
 const schema = Joi.object().keys({
   hashId: Joi.string().required().example('z812a63'),
-  name: Joi.string().required().example('My webhook'),
+  name: Joi.string().required().example('My webhook').max(255),
   createdAt: Joi.date().required().example('2019-12-31T15:23Z'),
 })
   .tag('supplierWebhook')

--- a/src/models/translations.ts
+++ b/src/models/translations.ts
@@ -1,19 +1,43 @@
 import Joi from 'joi';
 
 const translationStringSchema = Joi.string().allow('').required();
-const translationSchema = (example: string, limit = 9999) => Joi.alternatives().try(
-  Joi.object({
-    plural: translationStringSchema.max(limit),
-    singular: translationStringSchema.max(limit),
-  }),
-  translationStringSchema.example(example).max(limit),
-);
-const schema = (limit = 9999): Joi.AnySchema => Joi.object().keys({
-  en: translationSchema('English string', limit),
-  nl: translationSchema('Nederlandse string', limit),
-})
-  .tag('translations')
-  .meta({ className: 'translations' });
+const translationSchema = (example: string, limit?: number): Joi.AnySchema => {
+  if (limit !== undefined) {
+    return Joi.alternatives().try(
+      Joi.object({
+        plural: translationStringSchema.max(limit),
+        singular: translationStringSchema.max(limit),
+      }),
+      translationStringSchema.example(example).max(limit),
+    );
+  }
+
+  return Joi.alternatives().try(
+    Joi.object({
+      plural: translationStringSchema,
+      singular: translationStringSchema,
+    }),
+    translationStringSchema.example(example),
+  );
+};
+
+const schema = (limit?: number): Joi.AnySchema => {
+  if (limit !== undefined) {
+    return Joi.object().keys({
+      en: translationSchema('English string', limit),
+      nl: translationSchema('Nederlandse string', limit),
+    })
+      .tag('translations')
+      .meta({ className: 'translations' });
+  }
+
+  return Joi.object().keys({
+    en: translationSchema('English string'),
+    nl: translationSchema('Nederlandse string'),
+  })
+    .tag('translations')
+    .meta({ className: 'translations' });
+};
 
 type SimpleTranslation = string
 type PluralizedTranslation = Record<'plural' | 'singular', string>

--- a/src/models/translations.ts
+++ b/src/models/translations.ts
@@ -1,16 +1,16 @@
 import Joi from 'joi';
 
 const translationStringSchema = Joi.string().allow('').required();
-const translationSchema = (example: string) => Joi.alternatives().try(
+const translationSchema = (example: string, limit = 9999) => Joi.alternatives().try(
   Joi.object({
-    plural: translationStringSchema,
-    singular: translationStringSchema,
+    plural: translationStringSchema.max(limit),
+    singular: translationStringSchema.max(limit),
   }),
-  translationStringSchema.example(example),
+  translationStringSchema.example(example).max(limit),
 );
-const schema = Joi.object().keys({
-  en: translationSchema('English string'),
-  nl: translationSchema('Nederlandse string'),
+const schema = (limit = 9999): Joi.AnySchema => Joi.object().keys({
+  en: translationSchema('English string', limit),
+  nl: translationSchema('Nederlandse string', limit),
 })
   .tag('translations')
   .meta({ className: 'translations' });

--- a/src/routes/command-type/add.ts
+++ b/src/routes/command-type/add.ts
@@ -26,7 +26,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
   method: 'post',
   path: '/',
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema.required().example('Measurement cycle'),
+    name: stringOrTranslationsSchema().required().example('Measurement cycle'),
     start: Joi.string().valid('required', 'optional', 'disabled').default('optional').description('\'required\': user must provide command.startAt. \'optional\': user can provide command.startAt or a delay for the command to start after it is sent to the device. \'disabled\': user cannot provide command.startAt nor a delay.'),
     end: Joi.string().valid('required', 'optional', 'disabled').default('disabled').description('\'required\': user must provide command.endAt. \'optional\': user can provide command.endAt. \'disabled\': user cannot provide command.endAt.'),
     fieldConfigurations: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required()

--- a/src/routes/command-type/add.ts
+++ b/src/routes/command-type/add.ts
@@ -26,7 +26,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
   method: 'post',
   path: '/',
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema().required().example('Measurement cycle'),
+    name: stringOrTranslationsSchema(255).required().example('Measurement cycle'),
     start: Joi.string().valid('required', 'optional', 'disabled').default('optional').description('\'required\': user must provide command.startAt. \'optional\': user can provide command.startAt or a delay for the command to start after it is sent to the device. \'disabled\': user cannot provide command.startAt nor a delay.'),
     end: Joi.string().valid('required', 'optional', 'disabled').default('disabled').description('\'required\': user must provide command.endAt. \'optional\': user can provide command.endAt. \'disabled\': user cannot provide command.endAt.'),
     fieldConfigurations: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required()

--- a/src/routes/command-type/update.ts
+++ b/src/routes/command-type/update.ts
@@ -29,7 +29,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
     hashId: Joi.string().required().example('x18a92'),
   }).required(),
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema.example('Measurement cycle'),
+    name: stringOrTranslationsSchema().example('Measurement cycle'),
     start: Joi.string().valid('required', 'optional', 'disabled').description('\'required\': user must provide command.startAt. \'optional\': user can provide command.startAt or a delay for the command to start after it is sent to the device. \'disabled\': user cannot provide command.startAt nor a delay.'),
     end: Joi.string().valid('required', 'optional', 'disabled').description('\'required\': user must provide command.endAt. \'optional\': user can provide command.endAt. \'disabled\': user cannot provide command.endAt.'),
     fieldConfigurations: updatableFieldConfigurationsSchema(apiVersion).description('See the chapter on open fields on how to use this'),

--- a/src/routes/command-type/update.ts
+++ b/src/routes/command-type/update.ts
@@ -29,7 +29,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
     hashId: Joi.string().required().example('x18a92'),
   }).required(),
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema().example('Measurement cycle'),
+    name: stringOrTranslationsSchema(255).example('Measurement cycle'),
     start: Joi.string().valid('required', 'optional', 'disabled').description('\'required\': user must provide command.startAt. \'optional\': user can provide command.startAt or a delay for the command to start after it is sent to the device. \'disabled\': user cannot provide command.startAt nor a delay.'),
     end: Joi.string().valid('required', 'optional', 'disabled').description('\'required\': user must provide command.endAt. \'optional\': user can provide command.endAt. \'disabled\': user cannot provide command.endAt.'),
     fieldConfigurations: updatableFieldConfigurationsSchema(apiVersion).description('See the chapter on open fields on how to use this'),

--- a/src/routes/device-type/add.ts
+++ b/src/routes/device-type/add.ts
@@ -43,7 +43,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
   method: 'post',
   path: '/',
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema.required().example('Cathodic protection device').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
+    name: stringOrTranslationsSchema().required().example('Cathodic protection device').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
     eventHandler: Joi.string().max(1000000).required().example('[omitted]')
       .description('A javascript function that handles events. See the chapter "User defined code'),
     fieldConfigurations: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required()
@@ -53,12 +53,12 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
       .required()
       .description('Defines deviceFields on the location (pinGroup) the device is connected to. Can be used in report type functions. See the chapter on open fields on how to use this'),
     channels: Joi.array().items(Joi.object().keys({
-      name: stringOrTranslationsSchema.required().example('Red wire').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
+      name: stringOrTranslationsSchema().required().example('Red wire').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
       pinFieldConfigurations: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required()
         .description('Defines deviceFields on the pin the channel is connected to. Can be used in report type functions. See the chapter on open fields on how to use this'),
-      defaultPinName: stringOrTranslationsSchema.example('Anode').description('If undefined, the channel cannot be linked to a pin'),
+      defaultPinName: stringOrTranslationsSchema().example('Anode').description('If undefined, the channel cannot be linked to a pin'),
       charts: Joi.array().items(Joi.object().keys({
-        title: stringOrTranslationsSchema.allow(null).example('Red wire charts').required(),
+        title: stringOrTranslationsSchema().allow(null).example('Red wire charts').required(),
         series: Joi.array().items(Joi.object().keys({
           quantityHashId: Joi.string().example('x18a92').required(),
           color: Joi.string().example('#ff00ff').allow(null)
@@ -67,7 +67,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
       })),
     })).required().description('All measurements are registered on a channel. When a device is installed at a location (pinGroup), its channels are connected to the ports (pins) of the location(pinGroup).'),
     charts: Joi.array().items(Joi.object().keys({
-      title: stringOrTranslationsSchema.allow(null).example('Cathodic protection charts').required(),
+      title: stringOrTranslationsSchema().allow(null).example('Cathodic protection charts').required(),
       series: Joi.array().items(Joi.object().keys({
         channelIndex: Joi.number().integer().required(),
         quantityHashId: Joi.string().example('x18a92').required(),

--- a/src/routes/device-type/add.ts
+++ b/src/routes/device-type/add.ts
@@ -43,7 +43,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
   method: 'post',
   path: '/',
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema().required().example('Cathodic protection device').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
+    name: stringOrTranslationsSchema(255).required().example('Cathodic protection device').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
     eventHandler: Joi.string().max(1000000).required().example('[omitted]')
       .description('A javascript function that handles events. See the chapter "User defined code'),
     fieldConfigurations: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required()
@@ -53,12 +53,12 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
       .required()
       .description('Defines deviceFields on the location (pinGroup) the device is connected to. Can be used in report type functions. See the chapter on open fields on how to use this'),
     channels: Joi.array().items(Joi.object().keys({
-      name: stringOrTranslationsSchema().required().example('Red wire').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
+      name: stringOrTranslationsSchema(255).required().example('Red wire').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
       pinFieldConfigurations: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required()
         .description('Defines deviceFields on the pin the channel is connected to. Can be used in report type functions. See the chapter on open fields on how to use this'),
-      defaultPinName: stringOrTranslationsSchema().example('Anode').description('If undefined, the channel cannot be linked to a pin'),
+      defaultPinName: stringOrTranslationsSchema(255).example('Anode').description('If undefined, the channel cannot be linked to a pin'),
       charts: Joi.array().items(Joi.object().keys({
-        title: stringOrTranslationsSchema().allow(null).example('Red wire charts').required(),
+        title: stringOrTranslationsSchema(255).allow(null).example('Red wire charts').required(),
         series: Joi.array().items(Joi.object().keys({
           quantityHashId: Joi.string().example('x18a92').required(),
           color: Joi.string().example('#ff00ff').allow(null)
@@ -67,7 +67,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
       })),
     })).required().description('All measurements are registered on a channel. When a device is installed at a location (pinGroup), its channels are connected to the ports (pins) of the location(pinGroup).'),
     charts: Joi.array().items(Joi.object().keys({
-      title: stringOrTranslationsSchema().allow(null).example('Cathodic protection charts').required(),
+      title: stringOrTranslationsSchema(255).allow(null).example('Cathodic protection charts').required(),
       series: Joi.array().items(Joi.object().keys({
         channelIndex: Joi.number().integer().required(),
         quantityHashId: Joi.string().example('x18a92').required(),

--- a/src/routes/device-type/update.ts
+++ b/src/routes/device-type/update.ts
@@ -49,18 +49,18 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
     hashId: Joi.string().required().example('wasd2'),
   }).required(),
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema().example('Cathodic protection device').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
+    name: stringOrTranslationsSchema(255).example('Cathodic protection device').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
     eventHandler: Joi.string().max(1000000).description('A javascript function that handles events. See the chapter "User defined code"'),
     fieldConfigurations: updatableFieldConfigurationsSchema(apiVersion),
     pinGroupFieldConfigurations: updatableFieldConfigurationsSchema(apiVersion)
       .description('Defines deviceFields on the location (pinGroup) the device is connected to. Can be used in monitoring report type functions. See the chapter on open fields on how to use this'),
     channels: Joi.array().items(Joi.object().keys({
-      name: stringOrTranslationsSchema().required().example('Red wire').description('This name is also visible in environments. To get a uniform user experience, please provide the name in English'),
+      name: stringOrTranslationsSchema(255).required().example('Red wire').description('This name is also visible in environments. To get a uniform user experience, please provide the name in English'),
       pinFieldConfigurations: updatableFieldConfigurationsSchema(apiVersion).required()
         .description('Defines deviceFields on the pin the channel is connected to. Can be used in report type functions. See the chapter on open fields on how to use this'),
-      defaultPinName: stringOrTranslationsSchema().example('Anode').description('If undefined, the channel cannot be linked to a pin'),
+      defaultPinName: stringOrTranslationsSchema(255).example('Anode').description('If undefined, the channel cannot be linked to a pin'),
       charts: Joi.array().items(Joi.object().keys({
-        title: stringOrTranslationsSchema().allow(null).example('Red wire charts').required(),
+        title: stringOrTranslationsSchema(255).allow(null).example('Red wire charts').required(),
         series: Joi.array().items(Joi.object().keys({
           quantityHashId: Joi.string().example('x18a92').required(),
           color: Joi.string().example('#ff00ff').allow(null)
@@ -69,7 +69,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
       })),
     })).description('All measurements are registered on a channel. When a device is installed at a location (pinGroup), its channels are connected to the ports (pins) of the location (pinGroup). Be careful when altering channels that it does still make sense for already installed devices and historic condition reports. It is therefore not allowed to delete channels (therefore it is required that the array is not shorter than the existing channel array).'),
     charts: Joi.array().items(Joi.object().keys({
-      title: stringOrTranslationsSchema().allow(null).example('Cathodic protection charts').required(),
+      title: stringOrTranslationsSchema(255).allow(null).example('Cathodic protection charts').required(),
       series: Joi.array().items(Joi.object().keys({
         channelIndex: Joi.number().integer().required(),
         quantityHashId: Joi.string().example('x18a92').required(),

--- a/src/routes/device-type/update.ts
+++ b/src/routes/device-type/update.ts
@@ -49,18 +49,18 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
     hashId: Joi.string().required().example('wasd2'),
   }).required(),
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema.example('Cathodic protection device').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
+    name: stringOrTranslationsSchema().example('Cathodic protection device').description('This name is also visible in monitoring environments. To get a uniform user experience, please provide the name in English'),
     eventHandler: Joi.string().max(1000000).description('A javascript function that handles events. See the chapter "User defined code"'),
     fieldConfigurations: updatableFieldConfigurationsSchema(apiVersion),
     pinGroupFieldConfigurations: updatableFieldConfigurationsSchema(apiVersion)
       .description('Defines deviceFields on the location (pinGroup) the device is connected to. Can be used in monitoring report type functions. See the chapter on open fields on how to use this'),
     channels: Joi.array().items(Joi.object().keys({
-      name: stringOrTranslationsSchema.required().example('Red wire').description('This name is also visible in environments. To get a uniform user experience, please provide the name in English'),
+      name: stringOrTranslationsSchema().required().example('Red wire').description('This name is also visible in environments. To get a uniform user experience, please provide the name in English'),
       pinFieldConfigurations: updatableFieldConfigurationsSchema(apiVersion).required()
         .description('Defines deviceFields on the pin the channel is connected to. Can be used in report type functions. See the chapter on open fields on how to use this'),
-      defaultPinName: stringOrTranslationsSchema.example('Anode').description('If undefined, the channel cannot be linked to a pin'),
+      defaultPinName: stringOrTranslationsSchema().example('Anode').description('If undefined, the channel cannot be linked to a pin'),
       charts: Joi.array().items(Joi.object().keys({
-        title: stringOrTranslationsSchema.allow(null).example('Red wire charts').required(),
+        title: stringOrTranslationsSchema().allow(null).example('Red wire charts').required(),
         series: Joi.array().items(Joi.object().keys({
           quantityHashId: Joi.string().example('x18a92').required(),
           color: Joi.string().example('#ff00ff').allow(null)
@@ -69,7 +69,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
       })),
     })).description('All measurements are registered on a channel. When a device is installed at a location (pinGroup), its channels are connected to the ports (pins) of the location (pinGroup). Be careful when altering channels that it does still make sense for already installed devices and historic condition reports. It is therefore not allowed to delete channels (therefore it is required that the array is not shorter than the existing channel array).'),
     charts: Joi.array().items(Joi.object().keys({
-      title: stringOrTranslationsSchema.allow(null).example('Cathodic protection charts').required(),
+      title: stringOrTranslationsSchema().allow(null).example('Cathodic protection charts').required(),
       series: Joi.array().items(Joi.object().keys({
         channelIndex: Joi.number().integer().required(),
         quantityHashId: Joi.string().example('x18a92').required(),

--- a/src/routes/environment/add.ts
+++ b/src/routes/environment/add.ts
@@ -20,7 +20,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithoutClientOrSuppl
   method: 'post',
   path: '/',
   body: Joi.object().keys({
-    name: Joi.string().required().example('My monitoring environment'),
+    name: Joi.string().required().example('My monitoring environment').max(255),
   }).required(),
   right: {}, // everyone can add an environment
   response: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({

--- a/src/routes/measurement-filter/add.ts
+++ b/src/routes/measurement-filter/add.ts
@@ -28,8 +28,13 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
   method: 'post',
   path: '/',
   body: Joi.object().keys({
-    name: Joi.string().required().example('North'),
-    description: Joi.string().required().allow('').example('Temperatures in the North'),
+    name: Joi.string().required().example('North').max(100),
+    description: Joi
+      .string()
+      .required()
+      .allow('')
+      .example('Temperatures in the North')
+      .max(255),
     period: Joi.alternatives().try(
       Joi.string().valid('lastMonth', 'lastQuarter', 'lastYear').required().example('lastMonth'),
       Joi.object().keys({

--- a/src/routes/measurement-filter/update.ts
+++ b/src/routes/measurement-filter/update.ts
@@ -32,8 +32,8 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
     hashId: Joi.string().required().example('k8gh3'),
   }).required(),
   body: Joi.object().keys({
-    name: Joi.string().example('South'),
-    description: Joi.string().allow(''),
+    name: Joi.string().example('South').max(100),
+    description: Joi.string().allow('').max(255),
     period: Joi.alternatives().try(
       Joi.string().valid('lastMonth', 'lastQuarter', 'lastYear').required(),
       Joi.object().keys({

--- a/src/routes/measurement-threshold/find.ts
+++ b/src/routes/measurement-threshold/find.ts
@@ -51,7 +51,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
       .description('This is the last page if nextPageOffset is null'),
     rows: Joi.array().items(Joi.object().keys({
       quantity: Joi.object().keys({
-        name: stringOrTranslations.required().example('Temperature'),
+        name: stringOrTranslations().required().example('Temperature'),
         hashId: Joi.string().required().example('wasd2'),
         unit: Joi.string().allow(null).default(null)
           .example('K')

--- a/src/routes/quantity/add.ts
+++ b/src/routes/quantity/add.ts
@@ -26,7 +26,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClientAndSupplie
   method: 'post',
   path: '/',
   body: Joi.object().keys({
-    name: stringOrTranslationsSchema().required().example('Temperature'),
+    name: stringOrTranslationsSchema(255).required().example('Temperature'),
     color: Joi.string().default('#ff00ff').example('#ff00ff'),
     unit: Joi.string().allow(null).default(null).example('K')
       .description('Will be displayed with an SI-prefix (eg. k or M) if relevant'),

--- a/src/routes/quantity/add.ts
+++ b/src/routes/quantity/add.ts
@@ -26,7 +26,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClientAndSupplie
   method: 'post',
   path: '/',
   body: Joi.object().keys({
-    name: stringOrTranslationsSchema.required().example('Temperature'),
+    name: stringOrTranslationsSchema().required().example('Temperature'),
     color: Joi.string().default('#ff00ff').example('#ff00ff'),
     unit: Joi.string().allow(null).default(null).example('K')
       .description('Will be displayed with an SI-prefix (eg. k or M) if relevant'),

--- a/src/routes/quantity/update.ts
+++ b/src/routes/quantity/update.ts
@@ -30,7 +30,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClientAndSupplie
     hashId: Joi.string().required().example('sajia1'),
   }).required(),
   body: Joi.object().keys({
-    name: stringOrTranslationsSchema().example('Temperature'),
+    name: stringOrTranslationsSchema(255).example('Temperature'),
     color: Joi.string().example('#ff00ff'),
     unit: Joi.string().allow(null).example('K').description('Will be displayed with an SI-prefix (eg. k or M) if relevant'),
     defaultOrderOfMagnitude: Joi.number().integer().min(-128).max(127)

--- a/src/routes/quantity/update.ts
+++ b/src/routes/quantity/update.ts
@@ -30,7 +30,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClientAndSupplie
     hashId: Joi.string().required().example('sajia1'),
   }).required(),
   body: Joi.object().keys({
-    name: stringOrTranslationsSchema.example('Temperature'),
+    name: stringOrTranslationsSchema().example('Temperature'),
     color: Joi.string().example('#ff00ff'),
     unit: Joi.string().allow(null).example('K').description('Will be displayed with an SI-prefix (eg. k or M) if relevant'),
     defaultOrderOfMagnitude: Joi.number().integer().min(-128).max(127)

--- a/src/routes/supplier-report-type/add.ts
+++ b/src/routes/supplier-report-type/add.ts
@@ -24,7 +24,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
   method: 'post',
   path: '/',
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema().required().example('Temperature'),
+    name: stringOrTranslationsSchema(255).required().example('Temperature'),
     fieldConfigurations: Joi.object().keys({
       pinGroup: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required(),
       pin: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required(),

--- a/src/routes/supplier-report-type/add.ts
+++ b/src/routes/supplier-report-type/add.ts
@@ -24,7 +24,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
   method: 'post',
   path: '/',
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema.required().example('Temperature'),
+    name: stringOrTranslationsSchema().required().example('Temperature'),
     fieldConfigurations: Joi.object().keys({
       pinGroup: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required(),
       pin: Joi.array().items(baseFieldConfigurationSchema(apiVersion)).required(),

--- a/src/routes/supplier-report-type/update.ts
+++ b/src/routes/supplier-report-type/update.ts
@@ -31,7 +31,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
     hashId: Joi.string().required().example('y124as'),
   }).required(),
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema.example('Temperature'),
+    name: stringOrTranslationsSchema().example('Temperature'),
     fieldConfigurations: Joi.object().keys({
       pinGroup: updatableFieldConfigurationsSchema(apiVersion),
       pin: updatableFieldConfigurationsSchema(apiVersion),

--- a/src/routes/supplier-report-type/update.ts
+++ b/src/routes/supplier-report-type/update.ts
@@ -31,7 +31,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
     hashId: Joi.string().required().example('y124as'),
   }).required(),
   body: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
-    name: stringOrTranslationsSchema().example('Temperature'),
+    name: stringOrTranslationsSchema(255).example('Temperature'),
     fieldConfigurations: Joi.object().keys({
       pinGroup: updatableFieldConfigurationsSchema(apiVersion),
       pin: updatableFieldConfigurationsSchema(apiVersion),

--- a/src/routes/supplier-webhook/add.ts
+++ b/src/routes/supplier-webhook/add.ts
@@ -20,7 +20,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithSupplier = {
   method: 'post',
   path: '/',
   body: Joi.object().keys({
-    name: Joi.string().required().example('My webhook'),
+    name: Joi.string().required().example('My webhook').max(255),
     identifier: Joi.string().max(1000000).required().example(identifierExample)
       .description('A javascript function that returns deviceType and identifier. See the chapter "User defined code"'),
   }).required(),

--- a/test/string-or-translations.test.ts
+++ b/test/string-or-translations.test.ts
@@ -1,4 +1,6 @@
-import { getTranslatedString, StringOrTranslations } from '../src/models/string-or-translations';
+import { apiVersion } from '../src/index';
+import { versionedStringOrStringOrTranslationSchema, getTranslatedString, StringOrTranslations } from '../src/models/string-or-translations';
+import { schema as quantitySchema, Quantity } from '../src/models/quantity';
 
 test('test get a string out of stringOrTranslations object', () => {
   const stringOrTranslation: StringOrTranslations = 'stringValue';
@@ -20,4 +22,98 @@ test('test get non translated string out an object with only english', () => {
   };
   expect(getTranslatedString(stringOrTranslation, 'en')).toEqual('stringEN');
   expect(getTranslatedString(stringOrTranslation, 'nl')).toEqual('stringEN');
+});
+
+describe('versionedStringOrStringOrTranslationSchema', () => {
+  const normalStr = 'normalStr';
+  const longStr = 'x'.repeat(256);
+  const normalObj = {
+    en: normalStr,
+  };
+  const longObj = {
+    en: longStr,
+  };
+
+  describe('given an api version of 9 and above', () => {
+    describe('when I provide a string longer than 255 chars', () => {
+      test('it is not a valid schema', () => {
+        const result = versionedStringOrStringOrTranslationSchema(apiVersion + 1).validate(longStr);
+
+        expect(result.error).toBeDefined();
+        expect(result.error?.details[0].type).toEqual('string.max');
+
+        // extra test to test on a real schema
+        const quantity = (len: number): Quantity => ({
+          hashId: 'hashId',
+          name: {
+            en: 'x'.repeat(len),
+            nl: 'x'.repeat(len),
+          },
+          color: '#ffffff',
+          defaultOrderOfMagnitude: 1,
+          defaultHighThreshold: null,
+          defaultLowThreshold: null,
+          defaultCriticallyLowThreshold: null,
+          defaultCriticallyHighThreshold: null,
+          disableSiPrefixes: true,
+          unit: 'u',
+        });
+
+        let quantityValidation = quantitySchema(apiVersion).validate(quantity(256));
+
+        expect(quantityValidation.error).toBeDefined();
+        expect(quantityValidation.error?.details[0].type).toEqual('string.max');
+
+        quantityValidation = quantitySchema(apiVersion).validate(quantity(25));
+
+        expect(quantityValidation.error).not.toBeDefined();
+      });
+    });
+
+    describe('when I provide an object where one of (or both) string is longer than 255 chars', () => {
+      test('it is not a valid schema', () => {
+        const result = versionedStringOrStringOrTranslationSchema(apiVersion + 1).validate(longObj);
+
+        expect(result.error).toBeDefined();
+        expect(result.error?.details[0].type).toEqual('string.max');
+      });
+    });
+  });
+
+  describe('given an api version of 7 and above (but below 9)', () => {
+    describe('when I provide a string longer than 255 chars', () => {
+      test('it is a valid schema', () => {
+        const result = versionedStringOrStringOrTranslationSchema(8).validate(longStr);
+
+        expect(result.error).not.toBeDefined();
+      });
+    });
+
+    describe('when I provide an object where one of (or both) string is longer than 255 chars', () => {
+      test('it is a valid schema', () => {
+        const result = versionedStringOrStringOrTranslationSchema(8).validate(longObj);
+
+        expect(result.error).not.toBeDefined();
+      });
+    });
+  });
+
+  describe('given an api version of 6 (incl.) and below', () => {
+    describe('when I provide a string longer than 255 chars', () => {
+      test('it is a valid schema', () => {
+        const result = versionedStringOrStringOrTranslationSchema(6).validate(longStr);
+
+        expect(result.error).not.toBeDefined();
+      });
+    });
+
+    describe('when I provide an object', () => {
+      test('it is not a valid schema', () => {
+        const result = versionedStringOrStringOrTranslationSchema(6).validate(normalObj);
+
+        expect(result.error).toBeDefined();
+        expect(result.error?.details[0].type).toEqual('string.base');
+      });
+    });
+  });
 });

--- a/test/string-or-translations.test.ts
+++ b/test/string-or-translations.test.ts
@@ -80,25 +80,7 @@ describe('versionedStringOrStringOrTranslationSchema', () => {
     });
   });
 
-  describe('given an api version of 7 and above (but below 9)', () => {
-    describe('when I provide a string longer than 255 chars', () => {
-      test('it is a valid schema', () => {
-        const result = versionedStringOrStringOrTranslationSchema(8).validate(longStr);
-
-        expect(result.error).not.toBeDefined();
-      });
-    });
-
-    describe('when I provide an object where one of (or both) string is longer than 255 chars', () => {
-      test('it is a valid schema', () => {
-        const result = versionedStringOrStringOrTranslationSchema(8).validate(longObj);
-
-        expect(result.error).not.toBeDefined();
-      });
-    });
-  });
-
-  describe('given an api version of 6 (incl.) and below', () => {
+  describe('given an api version below version 9', () => {
     describe('when I provide a string longer than 255 chars', () => {
       test('it is a valid schema', () => {
         const result = versionedStringOrStringOrTranslationSchema(6).validate(longStr);


### PR DESCRIPTION
## Authors
@Arinono 

## Issue
Refs (and used by, kinda, not required, but better) withthegrid/platform-client#1407
Used by https://github.com/withthegrid/platform/pull/1907

While I was working on the ticket above: inputing very long names everywhere, I got an API error for a `quantity.unit` name being too long. DB schema has a `varchar(10)`, and the SDK doesn't check this.

So I'm opening a PR to add this to the SDK.

👀 ~As discussed with Rob, this won't be breaking change(s), since the API would have blocked the requests anyways.~
I introduced one 🤓 

## Implementation details

### quantity.unit

Limiting to 10 chars to follow the DB schema
<details><summary>unit name longer than 10 chars</summary>

![image](https://user-images.githubusercontent.com/10957531/197534473-8fbfbd3e-870a-4813-a211-09efdc51e3b9.png)

</details>

### Entities names 🚨 BREAKING 🚨 (stringOrTranslations)

The names of localisable entities were not limited in length.
So I updated the helper that was giving the schema for these to introduce a max length of `255` for version 9 (new version) onwards.

### measurement-filter

Add limit of `100` on name and `255` on description (add and update)

### webhook

Limited name to `255`











