### PR TITLE
fix(label): name length

### DIFF
--- a/src/models/label.ts
+++ b/src/models/label.ts
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 const schema = Joi.object().keys({
   hashId: Joi.string().required().example('u98a24'),
-  name: Joi.string().required().example('Fix this month'),
+  name: Joi.string().required().example('Fix this month').max(255),
   color: Joi.string().pattern(/^#[a-fA-F\d]{6}$/).required().description('#, followed by six hexadecimal characters')
     .example('#ff0000'),
   createdAt: Joi.date().required().example('2019-12-31T15:23Z'),

--- a/src/routes/label/add.ts
+++ b/src/routes/label/add.ts
@@ -16,7 +16,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
   method: 'post',
   path: '/',
   body: Joi.object().keys({
-    name: Joi.string().required().example('Fix this month'),
+    name: Joi.string().required().example('Fix this month').max(255),
     color: Joi.string().pattern(/^#[a-fA-F\d]{6}$/).required().description('#, followed by six hexadecimal characters')
       .example('#ff0000'),
   }).required(),

--- a/src/routes/label/update.ts
+++ b/src/routes/label/update.ts
@@ -20,7 +20,7 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
     hashId: Joi.string().required().example('u98a24'),
   }).required(),
   body: Joi.object().keys({
-    name: Joi.string(),
+    name: Joi.string().max(255),
     color: Joi.string().pattern(/^#[a-fA-F\d]{6}$/).description('#, followed by six hexadecimal characters'),
   }).required(),
   right: { environment: 'ISSUES' },


### PR DESCRIPTION
## Authors
@Arinono 

## Issues
None, but refs withthegrid/platform-client#1640

## Implementation details

I just noticed that the SDK was not checking the label name length limit. So I added it based on the DB schema.

![SCR-20221110-dqg](https://user-images.githubusercontent.com/10957531/201046212-1532d9b5-2946-40f2-ae73-e6630102455f.png)


## ⚠️ Notes

In theory it's a breaking change, in practice it's not. Feel free to add the breaking change in the commit squash body if you think it's necessary