### PR TITLE
feat(mthresholds): add tableController

### DIFF
--- a/src/routes/measurement-threshold/index.ts
+++ b/src/routes/measurement-threshold/index.ts
@@ -3,6 +3,7 @@ import * as set from './set';
 
 import Comms from '../../comms';
 import controllerGenerator, { Result } from '../../comms/controller';
+import TableController from '../../comms/table-controller';
 
 class MeasurementThresholdRoute {
   static routerPath = 'measurement-threshold';
@@ -35,6 +36,12 @@ class MeasurementThresholdRoute {
       MeasurementThresholdRoute.auth,
       this.comms,
     )(parameters);
+
+  findTableController = (parameters?: find.Query):
+    TableController<find.ResponseRow> => new TableController<find.ResponseRow>(
+      this.find,
+      parameters,
+    );
 }
 
 export default MeasurementThresholdRoute;


### PR DESCRIPTION
Is required by: https://github.com/withthegrid/platform-client/issues/1370

Adds the tableController so that it can be used in the frontend to create a matching table that can be sorted and paginated easily.