### PR TITLE
fix(chart.getPanels): make the query params optional

### DIFF
--- a/src/routes/chart/get-panels.ts
+++ b/src/routes/chart/get-panels.ts
@@ -13,7 +13,7 @@ const kindsResources = ['pinGroups', 'pins'] as const;
 type KindsResources = typeof kindsResources[number];
 
 type Request = {
-  query: Record<KindsHashIds, Array<HashId>>;
+  query: Partial<Record<KindsHashIds, Array<HashId>>>;
 }
 
 type Panel = {
@@ -24,10 +24,10 @@ type Panel = {
   },
 };
 
-type Response = Record<KindsResources, Array<{
+type Response = Partial<Record<KindsResources, Array<{
   hashId: HashId,
   panel: Panel,
-}>>;
+}>>>;
 
 const charts = (apiVersion: number) => Joi.object().keys({
   lastMode: Joi.string().valid('manual', 'automatic').example('automatic').required(),
@@ -41,19 +41,19 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
   method: 'get',
   path: '/panels',
   query: Joi.object().keys({
-    pinGroupHashIds: Joi.array().items(Joi.string()).max(30).required(),
-    pinHashIds: Joi.array().items(Joi.string()).max(30).required(),
+    pinGroupHashIds: Joi.array().items(Joi.string()).max(30),
+    pinHashIds: Joi.array().items(Joi.string()).max(30),
   }).required(),
   right: { environment: 'READ' },
   response: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({
     pinGroups: Joi.array().items(Joi.object().keys({
       hashId: Joi.string().required().example('dao97'),
       panel: charts(apiVersion),
-    }).required()).required(),
+    }).required()),
     pins: Joi.array().items(Joi.object().keys({
       hashId: Joi.string().required().example('e13d57'),
       panel: charts(apiVersion),
-    }).required()).required(),
+    }).required()),
   }),
   description: 'Get multiple chart panels from pinGroups and grids',
 };

--- a/src/routes/chart/get-panels.ts
+++ b/src/routes/chart/get-panels.ts
@@ -12,6 +12,14 @@ type KindsHashIds = typeof kindsHashIds[number];
 const kindsResources = ['pinGroups', 'pins'] as const;
 type KindsResources = typeof kindsResources[number];
 
+// We make eveything Partial because having everything required but allowing an empty array does not
+// work. The reason is that coming from the consummer, having empty array(s) is valid, then the
+// query goes through axios, which strips the empty query arrays. Later, when the platform receives
+// the query and validated the requests, the requests does not validates against the schema anymore.
+// One alternative would be to add a paramSerializer to axios to force to produce a query param for
+// empty arrays. But doing so would annoys Joi because `array[0]` cannot be an empty string.
+// So the next best thing we can do is this, allowing empty queries, and anserwing with empty
+// responses
 type Request = {
   query: Partial<Record<KindsHashIds, Array<HashId>>>;
 }
@@ -41,8 +49,8 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
   method: 'get',
   path: '/panels',
   query: Joi.object().keys({
-    pinGroupHashIds: Joi.array().items(Joi.string()).max(30),
-    pinHashIds: Joi.array().items(Joi.string()).max(30),
+    pinGroupHashIds: Joi.array().items(Joi.string().example('dao97')).max(30),
+    pinHashIds: Joi.array().items(Joi.string().example('e13d57')).max(30),
   }).required(),
   right: { environment: 'READ' },
   response: (apiVersion: number): Joi.ObjectSchema => Joi.object().keys({

--- a/src/routes/chart/update-panels.ts
+++ b/src/routes/chart/update-panels.ts
@@ -22,10 +22,10 @@ type Panel = {
 };
 
 type Request = {
-  body: Record<KindsResources, Array<{
+  body: Partial<Record<KindsResources, Array<{
     hashId: HashId,
     panel: Panel,
-  }>>
+  }>>>
 };
 
 type Response = void;
@@ -50,11 +50,11 @@ const controllerGeneratorOptions: ControllerGeneratorOptionsWithClient = {
     pinGroups: Joi.array().items(Joi.object().keys({
       hashId: Joi.string().required().example('dao97'),
       panel: panel.required(),
-    }).required()).required(),
+    }).required()),
     pins: Joi.array().items(Joi.object().keys({
       hashId: Joi.string().required().example('e13d57'),
       panel: panel.required(),
-    }).required()).required(),
+    }).required()),
   }).required(),
   right: { environment: 'REPORTS' },
   description: 'Update multiple chart panels',


### PR DESCRIPTION
## authors
@Arinono 

## issues
refs withthegrid/platform-client#2151

used by https://github.com/withthegrid/platform-client/pull/2152
used by https://github.com/withthegrid/platform-sdk-private/pull/281
used by https://github.com/withthegrid/platform/pull/2081

## impl details

When the array is empty, the SDK strips the query param from the query, so the schema doesn't type check